### PR TITLE
chore: pin pytest>=9.0.3 (CVE) + VoxCPM regression tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ curl localhost:7860/health
 curl "localhost:7860/synthesize?text=Hello&voice=galadriel" -o test.wav
 
 # Run tests (no GPU required)
-pip install pytest httpx
+pip install -r requirements-dev.txt
 pytest
 
 # Run a single test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development + test dependencies (not needed at runtime).
+#
+# Install: pip install -r requirements-dev.txt
+pytest>=9.0.3,<10.0
+httpx>=0.28,<1.0

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -112,3 +112,63 @@ def test_all_registered_backends_accept_lang_keyword():
         b = backends.get(name)
         sig = inspect.signature(b.synthesize)
         assert "lang" in sig.parameters, f"backend {name!r} missing lang kwarg"
+
+
+def test_voxcpm_synthesize_handles_generator_output():
+    """Regression: mlx-audio's VoxCPM.generate() yields GenerationResult objects
+    (dataclass with .audio = mx.array). Earlier code passed the generator directly
+    to np.asarray which raised TypeError. Mock the model to verify the generator
+    branch concatenates chunk audio correctly without loading mlx-audio."""
+    import sys
+    from types import SimpleNamespace
+    import numpy as np
+    from backends.voxcpm import VoxCPMBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxCPMBackend()
+    # Stub the model — yields two GenerationResult-shaped objects.
+    chunk_a = SimpleNamespace(audio=np.full(100, 0.1, dtype=np.float32))
+    chunk_b = SimpleNamespace(audio=np.full(150, 0.2, dtype=np.float32))
+
+    class _StubModel:
+        def generate(self, **kwargs):
+            yield chunk_a
+            yield chunk_b
+
+    backend._model = _StubModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/test.wav",
+        ref_text="ref",
+        extras=_read_only({}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+    assert sr == 44100  # NATIVE_SR
+    assert audio.shape == (250,)
+    assert audio.dtype == np.float32
+    # First 100 samples from chunk_a, next 150 from chunk_b
+    assert np.allclose(audio[:100], 0.1)
+    assert np.allclose(audio[100:], 0.2)
+
+
+def test_voxcpm_synthesize_raises_on_empty_generator():
+    """If generate() yields nothing, surface a clear error rather than
+    returning an empty array silently."""
+    import pytest as _pytest
+    from backends.voxcpm import VoxCPMBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxCPMBackend()
+
+    class _EmptyModel:
+        def generate(self, **kwargs):
+            return (x for x in ())  # empty generator (real GeneratorType)
+
+    backend._model = _EmptyModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/test.wav",
+        ref_text="ref",
+        extras=_read_only({}),
+    )
+    with _pytest.raises(RuntimeError, match="no audio chunks"):
+        backend.synthesize("hello", prepared, lang="en")


### PR DESCRIPTION
## Summary
Two safety follow-ups after PR #11:

- **requirements-dev.txt** pins \`pytest>=9.0.3,<10.0\` and \`httpx>=0.28,<1.0\`. Closes Dependabot moderate alert about pytest tmpdir handling.
- **Two regression tests** for the VoxCPM generator-handling bug fixed in PR #11. They use \`SimpleNamespace\` stubs to avoid loading mlx-audio, so they live in the default suite, not opt-in integration. Encodes the bug shape so it can't regress silently.

CLAUDE.md install instructions updated to use the new requirements file.

## Test Plan
- [x] 77 passing (75 + 2 new); 4 integration-gated
- [x] \`pip show pytest\` confirms 9.0.3
- [x] New \`test_voxcpm_synthesize_handles_generator_output\` runs in <0.01s with no model load

🤖 Generated with [Claude Code](https://claude.com/claude-code)