### PR TITLE
fix(backends/voxcpm): pass ref_audio (mx.array) + ref_text correctly

### DIFF
--- a/backends/voxcpm.py
+++ b/backends/voxcpm.py
@@ -104,12 +104,26 @@ class VoxCPMBackend(BackendBase):
             )
         # lang is validated above but not forwarded — mlx-audio's VoxCPM generate()
         # doesn't expose a lang kwarg; behavior is preserved.
+        # VoxCPM enters voice-cloning mode only when BOTH ref_audio (mx.array,
+        # already at NATIVE_SR) AND ref_text are passed. Earlier code passed
+        # the file path, which silently fell back to the default voice. Load
+        # the prepared (already-resampled to 44.1kHz) WAV into mx.array shape (T,).
+        import mlx.core as mx
+        ref_data, ref_sr = sf.read(prepared.ref_audio_path)
+        if ref_data.ndim > 1:
+            ref_data = ref_data.mean(axis=1)
+        if ref_sr != NATIVE_SR:
+            # prepare_voice should have already resampled; this is belt+braces.
+            from .voxcpm import _resample_cpu  # self-import for clarity
+            ref_data = _resample_cpu(ref_data.astype(np.float32), ref_sr, NATIVE_SR)
+        ref_array = mx.array(ref_data.astype(np.float32))
+
         kwargs = dict(
             text=text,
-            reference_wav_path=prepared.ref_audio_path,
+            ref_audio=ref_array,
         )
         if prepared.ref_text:
-            kwargs["prompt_text"] = prepared.ref_text
+            kwargs["ref_text"] = prepared.ref_text
         for k in ("cfg_value", "inference_timesteps"):
             if k in prepared.extras:
                 kwargs[k] = prepared.extras[k]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -114,12 +114,20 @@ def test_all_registered_backends_accept_lang_keyword():
         assert "lang" in sig.parameters, f"backend {name!r} missing lang kwarg"
 
 
-def test_voxcpm_synthesize_handles_generator_output():
+def _write_silence_wav(tmp_path):
+    """Helper: write a tiny 44.1 kHz silent WAV. Returns its path."""
+    import soundfile as sf
+    import numpy as np
+    p = str(tmp_path / "ref.wav")
+    sf.write(p, np.zeros(4410, dtype=np.float32), 44100)
+    return p
+
+
+def test_voxcpm_synthesize_handles_generator_output(tmp_path):
     """Regression: mlx-audio's VoxCPM.generate() yields GenerationResult objects
     (dataclass with .audio = mx.array). Earlier code passed the generator directly
     to np.asarray which raised TypeError. Mock the model to verify the generator
     branch concatenates chunk audio correctly without loading mlx-audio."""
-    import sys
     from types import SimpleNamespace
     import numpy as np
     from backends.voxcpm import VoxCPMBackend
@@ -137,7 +145,7 @@ def test_voxcpm_synthesize_handles_generator_output():
 
     backend._model = _StubModel()
     prepared = PreparedVoice(
-        ref_audio_path="/tmp/test.wav",
+        ref_audio_path=_write_silence_wav(tmp_path),
         ref_text="ref",
         extras=_read_only({}),
     )
@@ -151,7 +159,7 @@ def test_voxcpm_synthesize_handles_generator_output():
     assert np.allclose(audio[100:], 0.2)
 
 
-def test_voxcpm_synthesize_raises_on_empty_generator():
+def test_voxcpm_synthesize_raises_on_empty_generator(tmp_path):
     """If generate() yields nothing, surface a clear error rather than
     returning an empty array silently."""
     import pytest as _pytest
@@ -166,9 +174,50 @@ def test_voxcpm_synthesize_raises_on_empty_generator():
 
     backend._model = _EmptyModel()
     prepared = PreparedVoice(
-        ref_audio_path="/tmp/test.wav",
+        ref_audio_path=_write_silence_wav(tmp_path),
         ref_text="ref",
         extras=_read_only({}),
     )
     with _pytest.raises(RuntimeError, match="no audio chunks"):
         backend.synthesize("hello", prepared, lang="en")
+
+
+def test_voxcpm_synthesize_passes_mxarray_ref_audio_to_model(tmp_path):
+    """Regression for the kwarg-rename + mx.array conversion bug.
+
+    When BOTH ref_audio and ref_text are provided, voxcpm.py must:
+    - call generate() with kwarg names ref_audio (not reference_wav_path)
+      and ref_text (not prompt_text)
+    - pass ref_audio as an mx.array (the model's _encode_prompt_audio
+      expects a tensor, not a string path)
+    """
+    from types import SimpleNamespace
+    import numpy as np
+    import mlx.core as mx
+    from backends.voxcpm import VoxCPMBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxCPMBackend()
+    captured_kwargs = {}
+
+    class _CapturingModel:
+        def generate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(audio=np.zeros(10, dtype=np.float32))
+
+    backend._model = _CapturingModel()
+    prepared = PreparedVoice(
+        ref_audio_path=_write_silence_wav(tmp_path),
+        ref_text="reference text",
+        extras=_read_only({}),
+    )
+    backend.synthesize("hello", prepared, lang="en")
+
+    assert "ref_audio" in captured_kwargs, "must pass ref_audio (not reference_wav_path)"
+    assert "ref_text" in captured_kwargs, "must pass ref_text (not prompt_text)"
+    assert captured_kwargs["ref_text"] == "reference text"
+    # ref_audio must be an mx.array of shape (T,), not a path string.
+    ref = captured_kwargs["ref_audio"]
+    assert isinstance(ref, mx.array), f"ref_audio must be mx.array, got {type(ref).__name__}"
+    assert ref.ndim == 1, f"ref_audio must be 1-D, got shape {ref.shape}"
+    assert ref.shape[0] > 0


### PR DESCRIPTION
## Summary
VoxCPM was never actually voice-cloning in our integration. Two bugs stacked:

1. **Wrong kwarg names.** \`backends/voxcpm.py\` passed \`reference_wav_path\` and \`prompt_text\`, but VoxCPM's \`generate()\` expects \`ref_audio\` and \`ref_text\`. Wrong names absorbed by \`**kwargs\` and silently dropped — the cloning branch \`if ref_audio is not None and ref_text is not None\` never fired.

2. **Wrong type.** VoxCPM's \`_encode_prompt_audio\` expects an \`mx.array\` shape \`(T,)\`, not a path string. Load the (already-resampled to 44.1 kHz) ref WAV via soundfile and convert to \`mx.array\` before passing.

## Verification
After the fix, synthesizing the same text against picard, galadriel, and attenborough VoxCPM voices produces three distinct audio outputs:

\`\`\`
picard-voxcpm-15.wav: 282864 bytes, sha256 e049f9...
galadriel-voxcpm-15.wav: 282864 bytes, sha256 2aab88...
attenborough-voxcpm-15.wav: 649776 bytes, sha256 3e13f8...
\`\`\`

Different shasums + different durations → cloning is engaging the reference. Listen-test for fidelity is the operator's call before restoring the demo column (separate PR).

## Tests
- 82 passing (was 81 + 1 new conformance test \`test_voxcpm_synthesize_passes_mxarray_ref_audio_to_model\` that captures kwargs at the model boundary)
- Closes part of #14 (VoxCPM portion). Chatterbox quality investigation still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)