### PR TITLE
docs: comprehensive sweep — sync README/CLAUDE/AGENTS/site to shipped state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,14 @@ curl localhost:7860/health
 curl "localhost:7860/synthesize?text=Hello&voice=galadriel" -o test.wav
 
 # Run tests (no GPU required)
-pip install pytest httpx
+pip install -r requirements-dev.txt
 PYTHONPATH=. pytest
 
 # Run a single test
 PYTHONPATH=. pytest tests/test_server.py::test_health_returns_ok
+
+# Reload voices without restarting (after editing voices/*.json or running clone-voice.sh)
+afterwords reload
 ```
 
 Verify changes with `PYTHONPATH=. pytest` (no GPU required).
@@ -53,7 +56,7 @@ Verify changes with `PYTHONPATH=. pytest` (no GPU required).
 
 The server (server.py) and voice cloning (clone-voice.sh) are fully independent of Claude Code. The Claude Code integration is an optional layer installed by setup.sh when Claude Code is detected.
 
-1. **server.py** — FastAPI/Uvicorn TTS server on `localhost:7860`. Preloads four cloning backends via `backends.register_all()` at startup, serializes all synthesis through `_synth_lock` (MLX Metal is not thread-safe across backends). Voice profiles pin to a backend via the `backend` JSON field; dispatch is `backend = backends.get(profile.backend); backend.synthesize(text, profile.prepared)`. Voices are hardcoded defaults + auto-discovered JSON profiles from `voices/`. Two endpoints: `GET /health` and `GET /synthesize`.
+1. **server.py** — FastAPI/Uvicorn TTS server on `localhost:7860`. Preloads four cloning backends via `backends.register_all()` at startup, serializes all synthesis through `_synth_lock` (MLX Metal is not thread-safe across backends). Voice profiles pin to a backend via the `backend` JSON field; dispatch is `backend = backends.get(profile.backend); backend.synthesize(text, profile.prepared, lang)`. Voices are auto-discovered JSON profiles from `voices/`. Endpoints: `GET /health` (always; exposes `loaded_backends[*].supported_langs`), `GET /synthesize?text=...&voice=...&lang=en` (always), and `--allow-clone`-gated: `POST /synthesize` (JSON body), `POST /clone` (multipart upload), `POST /reload` (atomic add-only rescan), `DELETE /session/{id}`. Lang validation is per-backend; an unsupported lang raises `ValueError` mapped to HTTP 400 with `voice_backend` and `supported_langs`. Voice profiles can declare an optional `family` field; if a voice's backend doesn't support the requested lang, server auto-routes to a same-family voice on a backend that does (lookup under `_model_lock`). Lock-acquisition order is invariant: `_synth_lock` → `_model_lock`.
 
 2. **Claude Code hooks** (`~/.claude/hooks/`, optional) — `tts-hook.sh` fires on Stop events, extracts response text, passes through `strip-markdown.py`, and queues for synthesis. `tts-worker.sh` processes the queue (max 10 items) with `mkdir`-based locking (no `flock` on macOS), plays WAV via `afplay`, archives as MP3. Only installed when Claude Code is present.
 
@@ -62,6 +65,19 @@ The server (server.py) and voice cloning (clone-voice.sh) are fully independent 
 4. **Claude Code skill** (`skill/`) — A SKILL.md that enables natural-language TTS commands ("say this in picard's voice", "list voices", "set project voice"). Includes `scripts/speak.sh` helper for synthesis + playback.
 
 **Per-project voice override:** A `.afterwords` file in any repo root sets the voice for that project (read by the hook before each synthesis). Supports two formats: a single voice name (legacy), or an agent-to-voice mapping (`agent-name: voice-name`, one per line, with `default:` as fallback). The hook reads `agent_type` from the Stop event payload to resolve per-agent voices. Built-in subagent types (Explore, Plan, general-purpose) are silently skipped.
+
+## Backends
+
+Registry at `backends/__init__.py`; one Python file per backend implementing the `Backend` protocol (`load / validate_extras / prepare_voice / synthesize`).
+
+| Name | Size | Sample rate | ref_text policy |
+|------|------|-------------|-----------------|
+| `qwen3-0.6b` | 0.6B | 24 kHz | REQUIRED |
+| `qwen3-1.7b` | 1.7B | 24 kHz | REQUIRED |
+| `chatterbox` | 0.8B (fp16) | 24 kHz | OPTIONAL |
+| `voxcpm-1.5` | 2B (bf16) | 44.1 kHz | OPTIONAL |
+
+Cloning fidelity in current integration: Qwen3 sizes confirmed strong, VoxCPM cloning engages post-#16, Chatterbox cloning engages but fidelity unverified (issue #14).
 
 ## Key Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Verify changes with `pytest` (no GPU required). Run a single test with `pytest t
 
 The server (server.py) and voice cloning (clone-voice.sh) are fully independent of Claude Code. The Claude Code integration is an optional layer installed by setup.sh when Claude Code is detected.
 
-1. **server.py** — FastAPI/Uvicorn TTS server on `localhost:7860`. Preloads four cloning backends via `backends.register_all()` at startup, serializes all synthesis through `_synth_lock` (MLX Metal is not thread-safe across backends). Voice profiles pin to a backend via the `backend` JSON field; dispatch is `backend = backends.get(profile.backend); backend.synthesize(text, profile.prepared)`. Voices are hardcoded defaults + auto-discovered JSON profiles from `voices/`. Two endpoints: `GET /health` and `GET /synthesize`.
+1. **server.py** — FastAPI/Uvicorn TTS server on `localhost:7860`. Preloads four cloning backends via `backends.register_all()` at startup, serializes all synthesis through `_synth_lock` (MLX Metal is not thread-safe across backends). Voice profiles pin to a backend via the `backend` JSON field; dispatch is `backend = backends.get(profile.backend); backend.synthesize(text, profile.prepared, lang)`. Voices are auto-discovered JSON profiles from `voices/`. Endpoints: `GET /health` (always available; exposes `loaded_backends[*].supported_langs`), `GET /synthesize?text=...&voice=...&lang=en` (always), and four endpoints gated by `--allow-clone`: `POST /synthesize` (JSON body with optional `emotion` + `lang`), `POST /clone` (multipart audio upload), `POST /reload` (rescan `voices/*.json`, atomic add-only — see Hot-reload), `DELETE /session/{id}` (remove cloned-session voices + temp files). Lifespan context manager handles shutdown cleanup; `_sweep_orphaned_temp_files()` runs at startup before profile load to clear VoxCPM resampled refs from a prior crashed run.
 
 2. **Claude Code hooks** (`~/.claude/hooks/`, optional) — `tts-hook.sh` fires on Stop events, extracts response text, passes through `strip-markdown.py`, and queues for synthesis. `tts-worker.sh` processes the queue (max 10 items) with `mkdir`-based locking (no `flock` on macOS), plays WAV via `afplay`, archives as MP3. Only installed when Claude Code is present.
 
@@ -74,7 +74,22 @@ The `backends/` package exposes a `Backend` Protocol (in `backends/base.py`) and
 | `chatterbox` | 0.8B (fp16) | 24 kHz | OPTIONAL |
 | `voxcpm-1.5` | 2B (bf16) | 44.1 kHz | OPTIONAL |
 
+Each backend has a `supported_langs: tuple[str, ...]` advertising what BCP-47 codes it accepts. Backend.synthesize takes a required `lang: str` parameter and raises `ValueError` for unsupported codes — server maps that to HTTP 400 with `voice_backend` + `supported_langs` in the body.
+
 Adding a backend: create `backends/newmodel.py` implementing the Backend protocol, then add one line to `register_all()` in `backends/__init__.py`. The registry CLI (`python -m backends list | max-sample-rate | slug <name>`) is used by `clone-voice.sh` to stay backend-aware.
+
+## Voice-family routing
+
+Voice profiles can declare an optional `family: str` field (e.g. `"family": "picard"` on `picard.json`, `picard-qwen3-17b.json`, etc.). When a caller asks for a lang the voice's backend doesn't support, the server auto-routes to a same-family voice on a backend that does. The lookup runs under `_model_lock` to avoid racing with `/reload` Phase 3. Tiebreaker is `(duration_s or 0, confidence or 0, name)` for deterministic selection across `/reload` cycles. Voices with `family=None` (most gallery voices, all session-cloned voices) are never routed and never used as routing targets.
+
+## Hot-reload
+
+`POST /reload` (gated by `--allow-clone`) re-walks `voices/*.json` in three phases:
+1. Build new VoiceProfile per JSON under `_synth_lock` (prepare_voice may touch Metal). Track every profile's cleanup_paths + owns_temp_audio for rollback.
+2. **Atomic abort** — if any prepare_voice raises, delete every tracked temp file and return 500 with errors[]. VOICES is unchanged.
+3. **Add-only commit** under `_model_lock`: `VOICES[name] = profile` for each successful build. Voices whose JSON disappeared from disk are NOT removed (use `DELETE /session/{id}` or restart).
+
+CLI: `afterwords reload` curls the endpoint and pretty-prints the response.
 
 ## Key Constraints
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 33 voices included (18 shipped + 15 Doctor Who companions).
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across four MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5).
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -89,7 +89,29 @@ afterwords restart
 curl "http://localhost:7860/synthesize?text=Hello&voice=samantha" -o hello.wav
 ```
 
-Newly cloned voices are auto-discovered on server restart — no code edits needed to register them.
+**Newly cloned voices** are auto-discovered on server restart, OR pick them up without a restart:
+
+```bash
+afterwords reload   # rescans voices/, adds new profiles, no synthesis interruption
+```
+
+`reload` is add-only and atomic — if any new profile fails validation, the whole reload aborts and the previous voice set stays intact.
+
+## Languages
+
+The four backends advertise different language support. Ask `/health` to see what each one offers:
+
+```bash
+curl -s localhost:7860/health | jq '.loaded_backends | to_entries[] | {backend: .key, langs: .value.supported_langs}'
+```
+
+Pass `lang=` on a synthesis request when you want a non-English language:
+
+```bash
+curl "http://localhost:7860/synthesize?text=Ni+hao&voice=galadriel&lang=zh" -o hello-zh.wav
+```
+
+If the voice's backend doesn't support the requested language, and the voice belongs to a *family* (e.g. `picard`, `picard-voxcpm-15` etc. all have `family: picard` in their JSON), the server auto-routes to a same-family voice on a backend that does support it. If no family member supports the language, you get a clean 400 with the list of supported languages.
 
 ## Claude Code Skill
 
@@ -111,8 +133,8 @@ The skill handles voice selection, server health checks, synthesis, and playback
 │                                                             │
 │  ┌─────────────────────────┐                                │
 │  │  Multi-Backend TTS      │  ← Four MLX backends, ~10 GB   │
-│  │  localhost:7860          │  ← 15 voice profiles           │
-│  │  /synthesize?text=...    │  ← ~20s per sentence           │
+│  │  localhost:7860          │  ← 50+ voice profiles          │
+│  │  /synthesize?text=...    │  ← ~20s per sentence (Qwen3)   │
 │  └─────────┬───────────────┘                                │
 │            │                                                │
 │  ┌─────────┴───────────────┐  ┌──────────────────────────┐  │
@@ -133,20 +155,40 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. Four MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3 (0.6B & 1.7B), Chatterbox (0.8B), and VoxCPM (2B). They run on [MLX](https://github.com/ml-explore/mlx) — Apple's ML framework — and preload at startup (~10 GB total).
+No training or fine-tuning. Four MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), and VoxCPM 1.5 (ModelBest, en/zh). They run on [MLX](https://github.com/ml-explore/mlx) — Apple's ML framework — and preload at startup (~10 GB total).
+
+Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
 ### The Server
 
-FastAPI + Uvicorn serving WAV audio over HTTP. The model loads once at startup; each voice is a reference WAV + transcript string. All synthesis serialised via a threading lock (MLX Metal crashes on concurrent GPU access).
+FastAPI + Uvicorn serving WAV audio over HTTP. Backends load once at startup; each voice is a reference WAV + transcript string. All synthesis serialised via `_synth_lock` (MLX Metal is single-GPU regardless of backend). VOICES dict mutation is guarded by a separate `_model_lock`. Lock-acquisition order is always `_synth_lock` → `_model_lock` to avoid deadlock.
 
 ```
-GET /health
-  → {"status":"ok", "ready":true, "voices":["galadriel","samantha",...]}
+GET  /health
+       → {"status":"ok", "ready":true, "voices":[...],
+          "loaded_backends": {"qwen3-0.6b": {"loaded":true, "voice_count":..., "supported_langs":[...]}, ...}}
 
-GET /synthesize?text=Hello&voice=galadriel
-  → audio/wav (16-bit PCM)
-  → 400 if voice unknown (returns available voices)
-  → 503 if warming up
+GET  /synthesize?text=Hello&voice=galadriel&lang=en
+       → audio/wav (16-bit PCM)
+       → X-Backend, X-Synthesis-Time, X-Duration headers
+       → 400 if voice unknown OR lang unsupported (returns supported_langs)
+       → 503 if warming up
+
+POST /synthesize          (--allow-clone only)
+       Body: {"text":..., "voice":..., "emotion":..., "lang":"en"}
+       → audio/wav, same status codes as GET
+
+POST /clone               (--allow-clone only)
+       multipart: audio file, session_id, emotion, transcript?, backend?
+       → JSON {voice, backend, emotion, quality, sequence, ...}
+
+POST /reload              (--allow-clone only)
+       → JSON {status, reloaded:[names], errors:[]} on success (200)
+       → JSON {status:"failed", errors:[...]}        on abort   (500)
+       Add-only, atomic — if any voice fails to prepare, no changes committed.
+
+DELETE /session/{id}      (--allow-clone only)
+       → removes all voices for that session, cleans up temp files
 ```
 
 ### The Hook
@@ -173,7 +215,12 @@ afterwords/
 ├── clone-voice.sh        ← add more voices from YouTube
 ├── server.py             ← multi-voice TTS server
 ├── strip_markdown.py     ← text cleaner for TTS (also used by hooks)
-├── tests/                ← pytest suite (26 tests, no GPU needed)
+├── tests/                ← pytest suite (82+ tests, no GPU needed)
+├── backends/             ← Backend Protocol + 4 concrete backends + registry CLI
+├── scripts/              ← reclone-flagship.py, gen-comparison-audio.sh
+├── docs/                 ← demo site (deployed to GitHub Pages)
+├── requirements.txt      ← runtime deps
+├── requirements-dev.txt  ← test deps (pytest>=9.0.3, httpx)
 ├── skill/                ← Claude Code skill for natural-language TTS
 │   ├── SKILL.md          ← skill instructions
 │   └── scripts/speak.sh  ← synthesize + play helper
@@ -181,7 +228,7 @@ afterwords/
 │   ├── galadriel-ref.wav ← 15s reference (Cate Blanchett, LOTR)
 │   ├── samantha-ref.wav  ← (Scarlett Johansson, Her)
 │   ├── amy-pond-ref.wav  ← (Karen Gillan, Doctor Who)
-│   └── ...               ← 33 voices (18 shipped + 15 companions)
+│   └── ...               ← 50+ voices total; 3 flagships have per-backend variants
 └── README.md
 
 ~/.claude/                    ← only with Claude Code integration
@@ -258,16 +305,18 @@ afterwords/
 ## Testing
 
 ```bash
-pip install pytest httpx
+pip install -r requirements-dev.txt
 pytest
 ```
 
-Tests cover the server API (endpoint validation, error handling, voice resolution) and the strip-markdown text transform (every regex pattern, plus a golden test with a realistic Claude response). The server tests mock the ML model — no GPU or model download needed.
+Tests cover the server API (endpoint validation, error handling, voice resolution, hot-reload atomicity, lang routing across backend families), backend protocol conformance, the strip-markdown text transform, and lifecycle helpers (`_cleanup_current_voices`, `_sweep_orphaned_temp_files`). 82+ tests pass without loading any real model — a `FakeBackend` fixture stands in. Real-model integration tests are opt-in via `pytest -m integration`.
 
 Run a single test:
 
 ```bash
 pytest tests/test_strip_markdown.py::test_inline_code_keeps_content
+pytest tests/test_server.py -k reload         # all reload tests
+pytest tests/test_server.py -k routing        # all family-routing tests
 ```
 
 ## Managing the Server
@@ -279,6 +328,7 @@ afterwords restart     # restart after config changes
 afterwords status      # show health, PID, loaded voices
 afterwords logs        # tail the server log
 afterwords voices      # list available voices
+afterwords reload      # pick up new voices without restarting (no synth interruption)
 afterwords clone       # clone a new voice from YouTube
 afterwords uninstall   # remove service and optionally hooks
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -893,17 +893,25 @@ bash setup.sh</code><span class="copy-hint">click to copy</span></pre>
             <span class="param-name">voice</span>
             <span class="param-meta"><em>optional</em> &mdash; defaults to <code>galadriel</code>. Any name from /health</span>
           </div>
+          <div class="param-row">
+            <span class="param-name">lang</span>
+            <span class="param-meta"><em>optional</em> &mdash; BCP-47 language code, defaults to <code>en</code>. Must be in the voice's backend's <code>supported_langs</code> (see /health). If unsupported and the voice declares a <code>family</code>, the server auto-routes to a same-family voice on a backend that supports it.</span>
+          </div>
         </div>
 <pre><code># Synthesize and play
 curl "localhost:7860/synthesize?text=Hello+world&voice=snape" -o out.wav
 afplay out.wav
 
+# Non-English (the voice's backend must support the lang, or its family must)
+curl "localhost:7860/synthesize?text=Ni+hao&voice=galadriel&lang=zh" -o hi.wav
+
 # Pipe directly to speaker (macOS)
 curl -s "localhost:7860/synthesize?text=Testing" | afplay -</code><span class="copy-hint">click to copy</span></pre>
-        <p style="margin-top:0.75rem; font-size:0.9rem; color:var(--text-secondary);">Response includes timing headers: <code>X-Synthesis-Time</code>, <code>X-Duration</code>, <code>X-Sample-Rate</code>.</p>
+        <p style="margin-top:0.75rem; font-size:0.9rem; color:var(--text-secondary);">Response includes timing headers: <code>X-Synthesis-Time</code>, <code>X-Duration</code>, <code>X-Sample-Rate</code>, <code>X-Backend</code> (the actual backend that synthesized — may differ from the voice's pinned backend if family-routing kicked in).</p>
         <div class="response-codes">
           <span class="response-code success">200 audio/wav</span>
           <span class="response-code error">400 unknown voice</span>
+          <span class="response-code error">400 lang not supported</span>
           <span class="response-code error">400 text empty / too long</span>
           <span class="response-code error">500 synthesis failed</span>
           <span class="response-code error">503 warming up</span>
@@ -1005,10 +1013,29 @@ curl -X POST localhost:7860/clone \
 
       <div class="endpoint reveal">
         <div>
+          <span class="endpoint-method">POST</span>
+          <span class="endpoint-path">/reload</span>
+        </div>
+        <p class="endpoint-desc">Rescan <code>voices/*.json</code> and merge new or changed profiles into the live registry &mdash; no restart, no synthesis interruption. Add-only and atomic: if any profile fails to validate, no changes commit. Requires <code>--allow-clone</code>.</p>
+<pre><code># After cloning a new voice or editing voices/*.json:
+curl -X POST localhost:7860/reload | jq .
+
+# Or via the CLI wrapper:
+afterwords reload</code><span class="copy-hint">click to copy</span></pre>
+        <p style="margin-top:0.75rem; font-size:0.9rem; color:var(--text-secondary);">Returns <code>{"status":"ok","reloaded":[names...],"errors":[]}</code> on success or <code>{"status":"failed","errors":[{file, error}]}</code> on atomic abort. Voices removed from disk are NOT dropped &mdash; use <code>DELETE /session/{id}</code> for that.</p>
+        <div class="response-codes">
+          <span class="response-code success">200 OK</span>
+          <span class="response-code error">404 --allow-clone not enabled</span>
+          <span class="response-code error">500 atomic abort (errors[] populated)</span>
+        </div>
+      </div>
+
+      <div class="endpoint reveal">
+        <div>
           <span class="endpoint-method">DELETE</span>
           <span class="endpoint-path">/session/{session_id}</span>
         </div>
-        <p class="endpoint-desc">Remove all voice palette entries and files for a session. Requires <code>--allow-clone</code>.</p>
+        <p class="endpoint-desc">Remove all voice palette entries and files for a session. Also cleans up any backend temp files (e.g. VoxCPM resampled refs). Requires <code>--allow-clone</code>.</p>
 <pre><code>curl -X DELETE localhost:7860/session/my-voice</code><span class="copy-hint">click to copy</span></pre>
         <div class="response-codes">
           <span class="response-code success">200 OK</span>


### PR DESCRIPTION
## Summary
Six PRs landed today (#10, #11, #12, #13, #15, #16) without follow-up doc updates. This consolidates README/CLAUDE/AGENTS/website to reflect what's actually in main:

- **README**: voice count fixed (33 → 50+), test count fixed (26 → 82+), API surface expanded from 2 to 6 endpoints, new "Languages" section explaining lang param + family routing, hot-reload mentioned, requirements-dev.txt referenced.
- **CLAUDE.md / AGENTS.md**: "Two endpoints" replaced with full listing; new "Voice-family routing" and "Hot-reload" sections; AGENTS.md backends table with current cloning-fidelity per backend (Qwen3 confirmed; VoxCPM post-#16; Chatterbox unverified per #14).
- **docs/index.html**: GET /synthesize endpoint card adds lang= param + X-Backend header explanation; new POST /reload endpoint card with atomic-abort response shape.

## Test Plan
- [x] HTML parses cleanly
- [x] 82 tests still pass
- [x] No residual stale claims about voice/test/endpoint counts (grepped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)