### PR TITLE
fix(setup): register TTS hook on SubagentStop too, not just Stop

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -482,37 +482,53 @@ HOOK_CMD="bash ~/.claude/hooks/tts-hook.sh"
 HOOK_ENTRY="{\"type\": \"command\", \"command\": \"$HOOK_CMD\", \"timeout\": 120, \"async\": true}"
 HOOK_GROUP="{\"hooks\": [$HOOK_ENTRY]}"
 
-if [ -f "$SETTINGS" ]; then
-    if jq -e ".hooks.Stop[]?.hooks[]? | select(.command == \"$HOOK_CMD\")" "$SETTINGS" &>/dev/null; then
-        ok "TTS hook already configured in settings.json"
-    elif jq -e '.hooks.Stop | type == "array" and length > 0 and .[0].hooks' "$SETTINGS" &>/dev/null; then
-        info "Appending TTS hook to existing Stop hooks..."
+# Register the TTS hook on BOTH Stop (main conversation) and SubagentStop
+# (subagent completion) so per-agent .afterwords mappings actually fire.
+register_hook_event() {
+    local EVT="$1"
+    if jq -e ".hooks.${EVT}[]?.hooks[]? | select(.command == \"$HOOK_CMD\")" "$SETTINGS" &>/dev/null; then
+        ok "TTS hook already configured for ${EVT}"
+    elif jq -e ".hooks.${EVT} | type == \"array\" and length > 0 and .[0].hooks" "$SETTINGS" &>/dev/null; then
+        info "Appending TTS hook to existing ${EVT} hooks..."
         TMPF=$(mktemp)
         TMPFILES+=("$TMPF")
-        jq ".hooks.Stop[0].hooks += [$HOOK_ENTRY]" "$SETTINGS" > "$TMPF" \
+        jq ".hooks.${EVT}[0].hooks += [$HOOK_ENTRY]" "$SETTINGS" > "$TMPF" \
             && mv "$TMPF" "$SETTINGS"
-        ok "TTS hook appended to existing Stop hooks"
+        ok "TTS hook appended to existing ${EVT} hooks"
     elif jq -e '.hooks' "$SETTINGS" &>/dev/null; then
-        info "Adding Stop hook group to settings.json..."
+        info "Adding ${EVT} hook group to settings.json..."
         TMPF=$(mktemp)
         TMPFILES+=("$TMPF")
-        jq ".hooks.Stop = [$HOOK_GROUP]" "$SETTINGS" > "$TMPF" \
+        jq ".hooks.${EVT} = [$HOOK_GROUP]" "$SETTINGS" > "$TMPF" \
             && mv "$TMPF" "$SETTINGS"
-        ok "Stop hook added"
+        ok "${EVT} hook added"
     else
         info "Adding hooks to settings.json..."
         TMPF=$(mktemp)
         TMPFILES+=("$TMPF")
-        jq ". + {\"hooks\": {\"Stop\": [$HOOK_GROUP]}}" "$SETTINGS" > "$TMPF" \
+        jq ". + {\"hooks\": {\"${EVT}\": [$HOOK_GROUP]}}" "$SETTINGS" > "$TMPF" \
             && mv "$TMPF" "$SETTINGS"
-        ok "Stop hook added"
+        ok "${EVT} hook added"
     fi
+}
+
+if [ -f "$SETTINGS" ]; then
+    register_hook_event Stop
+    register_hook_event SubagentStop
 else
-    info "Creating settings.json with Stop hook..."
+    info "Creating settings.json with Stop + SubagentStop hooks..."
     cat > "$SETTINGS" <<SETTINGSEOF
 {
   "hooks": {
     "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "$HOOK_CMD",
+        "timeout": 120,
+        "async": true
+      }]
+    }],
+    "SubagentStop": [{
       "hooks": [{
         "type": "command",
         "command": "$HOOK_CMD",


### PR DESCRIPTION
## Summary
Per-agent \`.afterwords\` mappings (e.g. \`clara-oswald: clara-oswald\` for a custom subagent) require the TTS hook to fire on Claude Code's \`SubagentStop\` event — not just \`Stop\`. \`setup.sh\` only registered \`Stop\`, so subagent completions silently bypassed TTS. Only main-conversation default voices ever played, no matter how rich the agent mapping was.

## Root cause
Discovered today: in \`failure-first-embodied-ai/.afterwords\` the user maps research-analyst → clara-oswald, project-coordinator → donna-noble, etc. against project-local subagents in \`.claude/agents/*.md\`. The TTS archive showed 370+ \`the-doctor\` MP3s (the \`default:\` fallback for the main thread) but **zero** archives for any of the named agent voices — because the hook never fired for those subagents.

Adding \`SubagentStop\` to the user's \`~/.claude/settings.json\` and re-firing a simulated payload immediately produced a fresh \`clara-oswald-*.mp3\` archive. Confirmed.

## Change
- Refactored \`setup.sh\`'s settings.json mutation into a \`register_hook_event()\` helper that handles all four cases (already-set / appending to existing group / adding new group / creating hooks block from scratch). Called for Stop and SubagentStop.
- Initial-creation path emits both events in the seed JSON.
- The hook script (\`tts-hook.sh\`) didn't need changes — it already reads \`agent_type\` from the payload and resolves \`.afterwords\` mappings correctly.

## Test Plan
- [x] \`bash -n setup.sh\` passes
- [x] 82 pytests still pass
- [x] Manual verification: simulated SubagentStop payload with \`agent_type=clara-oswald\` produced a fresh clara-oswald MP3 in \`~/.claude/tts-archive/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)