### PR TITLE
feat: archive TTS responses with sidecar text + audit-archive tool

### DIFF
--- a/.claude/hooks/codex-tts-worker.sh
+++ b/.claude/hooks/codex-tts-worker.sh
@@ -53,7 +53,7 @@ while true; do
     [ -z "$LINE" ] && continue
 
     ENCODED=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$LINE" 2>/dev/null) || continue
-    STAMP=$(date +%Y%m%d-%H%M%S)
+    STAMP=$(date +%Y%m%d-%H%M%S)-$$-$RANDOM
 
     VOICE=""
     AW_FILE="$PROJECT_DIR/.afterwords"
@@ -85,7 +85,10 @@ while true; do
                 mv "$TRIMMED" "$WAVFILE"
             fi
             rm -f "$TRIMMED"
-            lame --quiet -V 2 "$WAVFILE" "$ARCHIVE_DIR/${VOICE:-default}-${STAMP}.mp3" 2>/dev/null
+            ARCHIVE_BASE="$ARCHIVE_DIR/${VOICE:-default}-${STAMP}"
+            if lame --quiet -V 2 "$WAVFILE" "$ARCHIVE_BASE.mp3" 2>/dev/null; then
+                printf '%s\n' "$LINE" > "$ARCHIVE_BASE.txt"
+            fi
             afplay "$WAVFILE" 2>/dev/null
         fi
     fi

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ bash clone-voice.sh "https://youtube.com/watch?v=..." galadriel 30
 
 The script downloads the audio, extracts a 15-second segment, denoises it, transcribes with Whisper, and saves a voice profile. Each voice is just a 700 KB WAV file — adding voices costs zero extra memory.
 
+### Auditing voice profiles
+
+If you hand-edit a `voices/*.json` `reference_text` after cloning (e.g. to correct Whisper mishearings), you can drift the transcript away from what the trimmed audio actually says — which degrades cloning fidelity. The audit tool re-transcribes every reference WAV and flags drift:
+
+```bash
+afterwords audit               # report only
+afterwords audit --fix         # overwrite reference_text with fresh Whisper output for flagged voices
+afterwords audit --voice picard
+```
+
+Flags raised: phantom canonical text (transcript materially longer than what's heard), mid-word truncation, mid-clip silence gaps ≥1.5s, and impossible char/sec ratios. Exits non-zero when any voice is flagged, so it's safe to wire into CI.
+
 ## Switching Voices
 
 **Per-project** — drop a `.afterwords` file in any repo:

--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Claude Code's [Stop hook](https://docs.anthropic.com/en/docs/claude-code/hooks) 
 
 ### The Queue
 
-Fast Claude conversations generate responses faster than TTS can synthesise. The worker processes a queue (max 10 entries), trimming oldest entries when it overflows. Each response is also archived as MP3 in `~/.claude/tts-archive/` (requires `lame`).
+Fast Claude conversations generate responses faster than TTS can synthesise. The worker processes a queue (max 10 entries), trimming oldest entries when it overflows. Each response is archived as an MP3 plus a sidecar TXT file in `~/.claude/tts-archive/` (requires `lame`), so archived speech can be audited later with `python scripts/audit-archive.py`.
+
+> **Privacy note:** the sidecar `.txt` files contain the exact text spoken by Claude — including code snippets, file paths, and anything else that appeared in a response. They persist indefinitely on local disk and are never uploaded anywhere. Clean periodically with `rm ~/.claude/tts-archive/*.txt` (or both `*.txt` and `*.mp3` to wipe the whole archive). If you'd rather not archive at all, remove the `lame ... && printf ...` block from `~/.claude/hooks/tts-worker.sh`.
 
 ## Requirements
 
@@ -229,7 +231,7 @@ afterwords/
 ├── strip_markdown.py     ← text cleaner for TTS (also used by hooks)
 ├── tests/                ← pytest suite (82+ tests, no GPU needed)
 ├── backends/             ← Backend Protocol + 4 concrete backends + registry CLI
-├── scripts/              ← reclone-flagship.py, gen-comparison-audio.sh
+├── scripts/              ← reclone-flagship.py, gen-comparison-audio.sh, audit-voice-transcripts.py, audit-archive.py
 ├── docs/                 ← demo site (deployed to GitHub Pages)
 ├── requirements.txt      ← runtime deps
 ├── requirements-dev.txt  ← test deps (pytest>=9.0.3, httpx)

--- a/afterwords.sh
+++ b/afterwords.sh
@@ -361,6 +361,19 @@ cmd_reload() {
     fi
 }
 
+cmd_audit() {
+    local script="${REPO_DIR}/scripts/audit-voice-transcripts.py"
+    if [ ! -f "$script" ]; then
+        fail "audit-voice-transcripts.py not found"
+    fi
+    if [ ! -d "${REPO_DIR}/.venv" ]; then
+        fail "venv missing — run setup.sh first"
+    fi
+    # shellcheck disable=SC1091
+    source "${REPO_DIR}/.venv/bin/activate"
+    python3 "$script" "$@"
+}
+
 cmd_clone() {
     if [ ! -f "$REPO_DIR/clone-voice.sh" ]; then
         fail "clone-voice.sh not found in ${REPO_DIR}"
@@ -524,6 +537,7 @@ cmd_help() {
     echo -e "    ${CYAN}voices${NC}      List available voices"
     echo -e "    ${CYAN}reload${NC}      Reload voices from disk without restarting"
     echo -e "    ${CYAN}clone${NC}       Clone a new voice from YouTube"
+    echo -e "    ${CYAN}audit${NC}       Audit voice profiles for transcript-vs-audio drift"
     echo -e "    ${CYAN}codex-hook${NC}  Start or stop the Codex CLI watcher"
     echo -e "    ${CYAN}uninstall${NC}   Remove the service and optionally hooks"
     echo
@@ -554,6 +568,7 @@ case "$COMMAND" in
     voices)    cmd_voices "$@" ;;
     reload)    cmd_reload "$@" ;;
     clone)     cmd_clone "$@" ;;
+    audit)     cmd_audit "$@" ;;
     codex-hook) cmd_codex_hook "$@" ;;
     uninstall) cmd_uninstall "$@" ;;
     help|--help|-h)  cmd_help ;;

--- a/scripts/audit-archive.py
+++ b/scripts/audit-archive.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Audit archived TTS responses against their requested text.
+
+The Claude/Codex workers archive paired files:
+  - {voice}-{stamp}.mp3: synthesized audio
+  - {voice}-{stamp}.txt: exact text sent to /synthesize
+
+This script transcribes the audio with faster-whisper, compares it to the
+sidecar text, and buckets results by input length and risky text patterns.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+
+
+DEFAULT_ARCHIVES = (
+    Path.home() / ".claude" / "tts-archive",
+    Path.home() / ".codex" / "tts-archive",
+)
+
+PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("digits", re.compile(r"\d")),
+    ("urls", re.compile(r"https?://|www\.", re.IGNORECASE)),
+    ("code_fences", re.compile(r"```")),
+    ("all_caps", re.compile(r"\b[A-Z]{3,}\b")),
+    ("em_dash", re.compile(r"\u2014|--")),
+)
+
+
+@dataclass
+class Pair:
+    audio: Path
+    text_path: Path | None
+    voice: str
+    stamp: str
+    expected: str = ""
+    transcript: str = ""
+    similarity: float | None = None
+    word_error_rate: float | None = None
+    length_bucket: str = ""
+    patterns: list[str] = field(default_factory=list)
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        if self.issues:
+            return False
+        if self.similarity is None or self.word_error_rate is None:
+            return True
+        return self.similarity >= 0.78 and self.word_error_rate <= 0.35
+
+
+def normalize_words(text: str) -> list[str]:
+    words = []
+    for token in text.lower().split():
+        token = "".join(ch for ch in token if ch.isalnum() or ch == "'")
+        if token:
+            words.append(token)
+    return words
+
+
+def word_error_rate(expected: list[str], actual: list[str]) -> float:
+    if not expected:
+        return 0.0 if not actual else 1.0
+
+    prev = list(range(len(actual) + 1))
+    for i, expected_word in enumerate(expected, 1):
+        cur = [i]
+        for j, actual_word in enumerate(actual, 1):
+            cost = 0 if expected_word == actual_word else 1
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost))
+        prev = cur
+    return prev[-1] / len(expected)
+
+
+def length_bucket(text: str) -> str:
+    n = len(normalize_words(text))
+    if n <= 20:
+        return "short"
+    if n <= 80:
+        return "medium"
+    return "long"
+
+
+def pattern_names(text: str) -> list[str]:
+    return [name for name, pattern in PATTERNS if pattern.search(text)]
+
+
+def split_voice_stamp(stem: str) -> tuple[str, str]:
+    match = re.match(r"^(.+)-(\d{8}-\d{6})$", stem)
+    if not match:
+        return stem, ""
+    return match.group(1), match.group(2)
+
+
+def discover_pairs(archive_dirs: list[Path]) -> list[Pair]:
+    pairs: list[Pair] = []
+    seen: set[Path] = set()
+    for archive_dir in archive_dirs:
+        if not archive_dir.exists():
+            continue
+        for audio in sorted(archive_dir.glob("*.mp3")):
+            audio = audio.resolve()
+            if audio in seen:
+                continue
+            seen.add(audio)
+
+            text_path = audio.with_suffix(".txt")
+            voice, stamp = split_voice_stamp(audio.stem)
+            pair = Pair(
+                audio=audio,
+                text_path=text_path if text_path.exists() else None,
+                voice=voice,
+                stamp=stamp,
+            )
+            if pair.text_path is None:
+                pair.issues.append("missing sidecar text")
+            else:
+                pair.expected = pair.text_path.read_text(encoding="utf-8").strip()
+                if not pair.expected:
+                    pair.issues.append("empty sidecar text")
+            pair.length_bucket = length_bucket(pair.expected)
+            pair.patterns = pattern_names(pair.expected)
+            pairs.append(pair)
+    return pairs
+
+
+def transcribe(audio: Path, model, lang: str | None) -> str:
+    kwargs = {"language": lang} if lang else {}
+    segments, _ = model.transcribe(str(audio), **kwargs)
+    return " ".join(segment.text.strip() for segment in segments).strip()
+
+
+def score_pair(pair: Pair, model, lang: str | None) -> None:
+    if not pair.expected:
+        return
+    pair.transcript = transcribe(pair.audio, model, lang)
+    if not pair.transcript:
+        pair.issues.append("empty whisper output")
+        return
+
+    expected_words = normalize_words(pair.expected)
+    actual_words = normalize_words(pair.transcript)
+    pair.similarity = SequenceMatcher(None, expected_words, actual_words).ratio()
+    pair.word_error_rate = word_error_rate(expected_words, actual_words)
+
+    if pair.similarity < 0.78:
+        pair.issues.append(f"low similarity: {pair.similarity:.2f}")
+    if pair.word_error_rate > 0.35:
+        pair.issues.append(f"high WER: {pair.word_error_rate:.2f}")
+
+
+def summarize(pairs: list[Pair]) -> dict[str, object]:
+    buckets: dict[str, dict[str, int]] = {}
+    patterns: dict[str, dict[str, int]] = {}
+
+    def add(target: dict[str, dict[str, int]], key: str, pair: Pair) -> None:
+        row = target.setdefault(key, {"total": 0, "ok": 0, "flagged": 0})
+        row["total"] += 1
+        if pair.ok:
+            row["ok"] += 1
+        else:
+            row["flagged"] += 1
+
+    for pair in pairs:
+        add(buckets, pair.length_bucket or "unknown", pair)
+        if pair.patterns:
+            for pattern in pair.patterns:
+                add(patterns, pattern, pair)
+        else:
+            add(patterns, "plain", pair)
+
+    return {
+        "total": len(pairs),
+        "ok": sum(1 for pair in pairs if pair.ok),
+        "flagged": sum(1 for pair in pairs if not pair.ok),
+        "by_length": buckets,
+        "by_pattern": patterns,
+    }
+
+
+def safe_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def pair_to_json(pair: Pair) -> dict[str, object]:
+    return {
+        "audio": safe_path(pair.audio),
+        "text": safe_path(pair.text_path) if pair.text_path else None,
+        "voice": pair.voice,
+        "stamp": pair.stamp,
+        "length_bucket": pair.length_bucket,
+        "patterns": pair.patterns,
+        "similarity": round(pair.similarity, 3) if pair.similarity is not None else None,
+        "word_error_rate": round(pair.word_error_rate, 3) if pair.word_error_rate is not None else None,
+        "issues": pair.issues,
+        "expected": pair.expected,
+        "transcript": pair.transcript,
+    }
+
+
+def render_text(pairs: list[Pair]) -> str:
+    summary = summarize(pairs)
+    lines = [
+        f"archive pairs: {summary['total']} total, {summary['ok']} ok, {summary['flagged']} flagged",
+        "",
+        "by length:",
+    ]
+    for name, row in sorted(summary["by_length"].items()):
+        lines.append(f"  {name}: {row['ok']} ok, {row['flagged']} flagged ({row['total']} total)")
+    lines.append("")
+    lines.append("by pattern:")
+    for name, row in sorted(summary["by_pattern"].items()):
+        lines.append(f"  {name}: {row['ok']} ok, {row['flagged']} flagged ({row['total']} total)")
+
+    flagged = [pair for pair in pairs if not pair.ok]
+    if flagged:
+        lines.append("")
+        lines.append("flagged:")
+        for pair in flagged:
+            score = "not scored"
+            if pair.similarity is not None and pair.word_error_rate is not None:
+                score = f"sim={pair.similarity:.2f}, wer={pair.word_error_rate:.2f}"
+            lines.append(f"  {safe_path(pair.audio)} ({score})")
+            for issue in pair.issues:
+                lines.append(f"    - {issue}")
+            if pair.expected and pair.transcript:
+                lines.append(f"    expected:   {pair.expected[:120]}")
+                lines.append(f"    transcript: {pair.transcript[:120]}")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-dir",
+        action="append",
+        type=Path,
+        help="Archive directory to scan. Repeatable. Defaults to Claude and Codex archives.",
+    )
+    parser.add_argument("--model", default="base.en", help="Whisper model name (default: base.en)")
+    parser.add_argument("--lang", default="en", help="Whisper language hint; empty disables hint")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    parser.add_argument(
+        "--no-transcribe",
+        action="store_true",
+        help="Only check MP3/TXT pairing and buckets; do not run Whisper.",
+    )
+    args = parser.parse_args(argv)
+
+    archive_dirs = args.archive_dir or list(DEFAULT_ARCHIVES)
+    pairs = discover_pairs([path.expanduser().resolve() for path in archive_dirs])
+    if not pairs:
+        print("no archived MP3 files found", file=sys.stderr)
+        return 2
+
+    if not args.no_transcribe:
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError:
+            print("faster-whisper not installed. pip install faster-whisper", file=sys.stderr)
+            return 2
+
+        print(f"loading whisper {args.model}...", file=sys.stderr)
+        model = WhisperModel(args.model, compute_type="int8")
+        lang = args.lang or None
+        for pair in pairs:
+            try:
+                score_pair(pair, model, lang)
+            except Exception as exc:
+                pair.issues.append(f"transcription error: {exc}")
+
+    if args.json:
+        print(json.dumps({"summary": summarize(pairs), "pairs": [pair_to_json(p) for p in pairs]}, indent=2))
+    else:
+        print(render_text(pairs))
+
+    return 1 if any(not pair.ok for pair in pairs) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit-voice-transcripts.py
+++ b/scripts/audit-voice-transcripts.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Audit voice profiles for transcript-vs-audio drift.
+
+For each voices/*.json:
+  - Re-transcribe the referenced WAV with faster-whisper
+  - Compare against the JSON's reference_text
+  - Flag drift: phantom text, truncation, silence gaps, impossible cps
+
+Usage:
+    python scripts/audit-voice-transcripts.py [--fix] [--voice NAME] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_VOICES = REPO / "voices"
+
+# Heuristic thresholds
+CPS_MAX = 22.0          # chars/sec; English natural speech ~14-17
+SIM_MIN = 0.55          # SequenceMatcher ratio on normalized word lists
+LEN_RATIO_MAX = 1.6     # ref_text words / whisper words; >1.6 = phantom canonical text
+SILENCE_GAP_S = 1.5     # mid-clip gap that hurts conditioning
+SILENCE_RMS = 0.005     # RMS threshold for silence (assumes ref WAVs are normalized to ±1.0)
+
+# Issue codes that indicate a *text* problem (so --fix should rewrite reference_text).
+# Audio-only issues (silence, missing-wav) are not fixable by editing text.
+TEXT_ISSUE_PREFIXES = ("phantom", "low similarity", "impossibly fast", "empty whisper", "likely truncated")
+
+# ANSI
+RED = "\033[0;31m"; GRN = "\033[0;32m"; YLW = "\033[0;33m"
+DIM = "\033[2m"; BLD = "\033[1m"; NC = "\033[0m"
+
+
+@dataclass
+class Finding:
+    voice: str
+    json_path: Path
+    wav: str
+    duration_s: float
+    ref_text: str
+    whisper_text: str
+    issues: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+    @property
+    def has_text_issue(self) -> bool:
+        return any(any(i.startswith(p) for p in TEXT_ISSUE_PREFIXES) for i in self.issues)
+
+
+def normalize(s: str) -> list[str]:
+    out = []
+    for tok in s.lower().split():
+        tok = "".join(c for c in tok if c.isalnum() or c == "'")
+        if tok:
+            out.append(tok)
+    return out
+
+
+def safe_resolve(base: Path, ref: str) -> Path | None:
+    """Resolve `ref` against `base`; reject anything that escapes `base`."""
+    if not ref:
+        return None
+    candidate = (base / ref).resolve()
+    base_resolved = base.resolve()
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError:
+        return None
+    return candidate
+
+
+def load_audio(path: Path):
+    import soundfile as sf
+    audio, sr = sf.read(str(path))
+    if hasattr(audio, "ndim") and audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    return audio, sr
+
+
+def detect_silence_gaps(audio, sr: int, win_s: float = 0.1) -> list[tuple[float, float]]:
+    """Return mid-clip silence regions >= SILENCE_GAP_S as (start_s, end_s)."""
+    import numpy as np
+    win = max(1, int(sr * win_s))
+    n = len(audio)
+    gaps: list[tuple[float, float]] = []
+    in_gap = False
+    gap_start_w = 0
+    for w in range(0, n, win):
+        chunk = audio[w:w + win]
+        rms = float(np.sqrt(np.mean(chunk * chunk))) if len(chunk) else 0.0
+        silent = rms < SILENCE_RMS
+        if silent and not in_gap:
+            in_gap = True
+            gap_start_w = w
+        elif not silent and in_gap:
+            in_gap = False
+            dur = (w - gap_start_w) / sr
+            if dur >= SILENCE_GAP_S:
+                gaps.append((gap_start_w / sr, w / sr))
+    # Trailing gap that runs to end of file is treated as natural silence, not flagged.
+    # Leading silence (start < 0.3s) is also natural; skip.
+    return [(a, b) for (a, b) in gaps if a > 0.3]
+
+
+def transcribe(wav_path: Path, model, lang: str | None) -> str:
+    kwargs = {"language": lang} if lang else {}
+    segments, _ = model.transcribe(str(wav_path), **kwargs)
+    return " ".join(seg.text.strip() for seg in segments).strip()
+
+
+def evaluate(profile: dict, ref_text: str, whisper_text: str, duration: float, audio_gaps: list[tuple[float, float]]) -> list[str]:
+    issues: list[str] = []
+
+    if not ref_text.strip():
+        issues.append("empty reference_text")
+        return issues
+
+    if not whisper_text.strip():
+        issues.append("empty whisper output (audio may be silent or unrecognized speech)")
+        # Still run cps + silence checks; skip text comparisons
+    else:
+        ref_words = normalize(ref_text)
+        wh_words = normalize(whisper_text)
+        if wh_words:
+            ratio = len(ref_words) / max(1, len(wh_words))
+            if ratio > LEN_RATIO_MAX:
+                issues.append(
+                    f"phantom text suspected: transcript {len(ref_words)}w vs whisper {len(wh_words)}w "
+                    f"(ratio {ratio:.2f})"
+                )
+        if ref_words and wh_words:
+            sim = SequenceMatcher(None, ref_words, wh_words).ratio()
+            if sim < SIM_MIN:
+                issues.append(f"low similarity to whisper: {sim:.2f} (<{SIM_MIN})")
+
+        # Truncation: ref_text's last word doesn't appear at the tail of whisper output.
+        # Avoids the false-positive "ends mid-word" check that tripped on every
+        # transcript without terminal punctuation.
+        ref_words = normalize(ref_text)
+        wh_words_full = normalize(whisper_text)
+        if ref_words and wh_words_full:
+            last_ref = ref_words[-1]
+            last_three_wh = wh_words_full[-3:]
+            ref_ends_with_letter = ref_text.rstrip()[-1:].isalpha()
+            if ref_ends_with_letter and last_ref not in last_three_wh:
+                # Whisper kept going past where ref_text stops, AND ref_text has no terminal
+                # punctuation — strong signal of mid-word truncation.
+                issues.append(f"likely truncated: last word '{last_ref}' not in whisper tail {last_three_wh}")
+
+    # Char/sec
+    if duration > 0:
+        cps = len(ref_text) / duration
+        if cps > CPS_MAX:
+            issues.append(f"impossibly fast: {cps:.1f} cps (>{CPS_MAX})")
+
+    for a, b in audio_gaps:
+        issues.append(f"mid-clip silence: {a:.1f}-{b:.1f}s ({b-a:.1f}s)")
+
+    return issues
+
+
+def audit_one(json_path: Path, voices_dir: Path, whisper_cache: dict[Path, str], model) -> Finding:
+    profile = json.loads(json_path.read_text())
+    name = profile.get("name", json_path.stem)
+    ref_audio = profile.get("reference_audio") or ""
+    ref_text = profile.get("reference_text", "") or ""
+    lang = profile.get("language", "en")  # default English; profile may override
+
+    wav_path = safe_resolve(voices_dir, ref_audio)
+    if wav_path is None or not wav_path.exists():
+        f = Finding(name, json_path, ref_audio, 0.0, ref_text, "")
+        if not ref_audio:
+            f.issues.append("missing reference_audio field")
+        elif wav_path is None:
+            f.issues.append(f"reference_audio escapes voices/ or is invalid: {ref_audio}")
+        else:
+            f.issues.append(f"reference_audio file not found: {ref_audio}")
+        return f
+
+    audio, sr = load_audio(wav_path)
+    duration = len(audio) / sr
+
+    if wav_path not in whisper_cache:
+        whisper_cache[wav_path] = transcribe(wav_path, model, lang)
+    whisper_text = whisper_cache[wav_path]
+
+    gaps = detect_silence_gaps(audio, sr)
+    finding = Finding(name, json_path, wav_path.name, duration, ref_text, whisper_text)
+    finding.issues = evaluate(profile, ref_text, whisper_text, duration, gaps)
+    return finding
+
+
+def fix_finding(finding: Finding) -> bool:
+    """Replace reference_text with whisper output, but only for text-type issues."""
+    if not finding.has_text_issue or not finding.whisper_text.strip():
+        return False
+    profile = json.loads(finding.json_path.read_text())
+    if profile.get("reference_text") == finding.whisper_text:
+        return False
+    profile["reference_text"] = finding.whisper_text
+    finding.json_path.write_text(json.dumps(profile, indent=2, ensure_ascii=False) + "\n")
+    return True
+
+
+def safe_relative(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO))
+    except ValueError:
+        return str(p)
+
+
+def render_report(findings: list[Finding], use_color: bool = True) -> str:
+    def c(code: str, s: str) -> str:
+        return f"{code}{s}{NC}" if use_color else s
+
+    lines = []
+    bad = [f for f in findings if not f.ok]
+    good = [f for f in findings if f.ok]
+
+    for f in findings:
+        if f.ok:
+            lines.append(f"  {c(GRN, '✓')} {f.voice} {c(DIM, f'({f.duration_s:.1f}s)')}")
+        else:
+            lines.append(f"  {c(RED, '✗')} {c(BLD, f.voice)} {c(DIM, f'({f.duration_s:.1f}s, {f.wav})')}")
+            for issue in f.issues:
+                lines.append(f"      {c(YLW, '•')} {issue}")
+            if f.whisper_text and f.ref_text != f.whisper_text:
+                lines.append(f"      {c(DIM, 'ref:')}     {f.ref_text[:120]}")
+                lines.append(f"      {c(DIM, 'whisper:')} {f.whisper_text[:120]}")
+
+    lines.append("")
+    lines.append(f"  {len(good)} ok, {c(RED, str(len(bad)))} flagged out of {len(findings)}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fix", action="store_true",
+                    help="Overwrite reference_text with Whisper output for voices flagged with text issues")
+    ap.add_argument("--voice", help="Audit a single voice by name (json stem)")
+    ap.add_argument("--json", action="store_true", help="Emit JSON report instead of text")
+    ap.add_argument("--voices-dir", default=str(DEFAULT_VOICES), help="Path to voices/")
+    ap.add_argument("--model", default="base.en", help="Whisper model (default: base.en)")
+    args = ap.parse_args()
+
+    voices_dir = Path(args.voices_dir).resolve()
+    profiles = sorted(voices_dir.glob("*.json"))
+    if args.voice:
+        profiles = [p for p in profiles if p.stem == args.voice]
+        if not profiles:
+            print(f"no profile matching name={args.voice}", file=sys.stderr)
+            return 2
+
+    if not profiles:
+        print("no voice profiles found", file=sys.stderr)
+        return 2
+
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        print("faster-whisper not installed. pip install faster-whisper", file=sys.stderr)
+        return 2
+
+    print(f"  loading whisper {args.model}...", file=sys.stderr)
+    model = WhisperModel(args.model, compute_type="int8")
+
+    cache: dict[Path, str] = {}
+    findings: list[Finding] = []
+    for jp in profiles:
+        try:
+            findings.append(audit_one(jp, voices_dir, cache, model))
+        except Exception as e:
+            f = Finding(jp.stem, jp, "", 0.0, "", "")
+            f.issues.append(f"audit error: {e}")
+            findings.append(f)
+
+    if args.fix:
+        fixed = 0
+        for i, f in enumerate(findings):
+            if f.has_text_issue and fix_finding(f):
+                fixed += 1
+                # Re-audit so the report and exit code reflect post-fix state.
+                findings[i] = audit_one(f.json_path, voices_dir, cache, model)
+        print(f"  fixed reference_text in {fixed} profile(s)", file=sys.stderr)
+
+    if args.json:
+        out = [
+            {
+                "voice": f.voice,
+                "json": safe_relative(f.json_path),
+                "wav": f.wav,
+                "duration_s": round(f.duration_s, 2),
+                "issues": f.issues,
+                "reference_text": f.ref_text,
+                "whisper_text": f.whisper_text,
+            }
+            for f in findings
+        ]
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+    else:
+        print(render_report(findings, use_color=sys.stdout.isatty()))
+
+    return 1 if any(not f.ok for f in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.sh
+++ b/setup.sh
@@ -426,7 +426,7 @@ while true; do
     [ -z "$LINE" ] && continue
 
     ENCODED=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$LINE" 2>/dev/null) || continue
-    STAMP=$(date +%Y%m%d-%H%M%S)
+    STAMP=$(date +%Y%m%d-%H%M%S)-$$-$RANDOM
 
     # Resolve voice: .afterwords mapping → .afterwords single → server default
     VOICE=""
@@ -460,7 +460,10 @@ while true; do
                 mv "$TRIMMED" "$WAVFILE"
             fi
             rm -f "$TRIMMED"
-            lame --quiet -V 2 "$WAVFILE" "$ARCHIVE_DIR/${VOICE}-${STAMP}.mp3" 2>/dev/null
+            ARCHIVE_BASE="$ARCHIVE_DIR/${VOICE:-default}-${STAMP}"
+            if lame --quiet -V 2 "$WAVFILE" "$ARCHIVE_BASE.mp3" 2>/dev/null; then
+                printf '%s\n' "$LINE" > "$ARCHIVE_BASE.txt"
+            fi
             afplay "$WAVFILE" 2>/dev/null
         fi
     fi

--- a/tests/test_audit_archive.py
+++ b/tests/test_audit_archive.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "audit-archive.py"
+SPEC = importlib.util.spec_from_file_location("audit_archive", SCRIPT)
+audit_archive = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["audit_archive"] = audit_archive
+SPEC.loader.exec_module(audit_archive)
+
+
+def test_word_error_rate_counts_insertions_deletions_and_substitutions():
+    assert audit_archive.word_error_rate(["hello", "world"], ["hello", "there"]) == 0.5
+    assert audit_archive.word_error_rate(["hello"], ["hello", "there"]) == 1.0
+    assert audit_archive.word_error_rate(["hello", "there"], ["hello"]) == 0.5
+
+
+def test_buckets_input_lengths():
+    assert audit_archive.length_bucket("one two three") == "short"
+    assert audit_archive.length_bucket("word " * 40) == "medium"
+    assert audit_archive.length_bucket("word " * 100) == "long"
+
+
+def test_detects_risky_text_patterns():
+    text = "CALL 123 now -- see https://example.com and ```python"
+    assert audit_archive.pattern_names(text) == [
+        "digits",
+        "urls",
+        "code_fences",
+        "all_caps",
+        "em_dash",
+    ]
+
+
+def test_discovers_mp3_txt_pairs(tmp_path):
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    (archive / "picard-20260428-101112.mp3").write_bytes(b"fake")
+    (archive / "picard-20260428-101112.txt").write_text("Make it so.", encoding="utf-8")
+
+    pairs = audit_archive.discover_pairs([archive])
+
+    assert len(pairs) == 1
+    assert pairs[0].voice == "picard"
+    assert pairs[0].stamp == "20260428-101112"
+    assert pairs[0].expected == "Make it so."
+    assert pairs[0].issues == []


### PR DESCRIPTION
## Summary
- Workers now write paired \`{voice}-{stamp}.txt\` sidecars next to each archived MP3, so synthesized speech can be scored against the exact text it was asked to speak
- Stamps gain \`-\$\$-\$RANDOM\` suffix so within-second collisions can't overwrite archived data
- New \`scripts/audit-archive.py\` discovers MP3/TXT pairs across Claude + Codex archives, transcribes via faster-whisper, scores similarity + WER, buckets by input length and risky text patterns (digits, URLs, code fences, ALL CAPS, em dash)
- Stacks on top of #26 (voice-audit tool); merge #26 first, this then becomes a clean diff against main

## Background
This is the foundation for the TTS chunking experiment. Today the hook synthesizes the entire Claude response as one blob — we have 1,060+ archived MP3s but no paired text, so we couldn't score faithfulness historically. With sidecars going forward we can answer empirically: at what input length does TTS quality fall apart, and which text patterns (digits, URLs, etc.) are the worst offenders. Once the data accumulates we'll choose a chunking strategy by evidence rather than guess.

## QA pipeline
- **codex**: implemented the change
- **gemini**: independent review (caught privacy + STAMP collision concerns)
- **live-system check**: caught the deployment gap — codex couldn't write \`~/.claude/hooks/tts-worker.sh\` from sandbox, so the live hook had to be patched separately
- All three workers (live hook, setup.sh template, codex variant) verified identical

## Test plan
- [x] \`pytest tests/test_audit_archive.py\` — 4/4 pass (WER, length bucketing, pattern detection, pair discovery)
- [x] \`bash -n\` clean on all three worker scripts
- [x] End-to-end smoke: write fake pair → \`audit-archive.py --no-transcribe\` → correct counts + exit code
- [ ] Real-world: trigger a Claude response, confirm \`{voice}-{stamp}.{mp3,txt}\` both appear in \`~/.claude/tts-archive/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)