### PR TITLE
feat: add Voxtral TTS backend (closes #5)

### DIFF
--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -31,11 +31,13 @@ def register_all() -> None:
     from .qwen3 import Qwen3Backend
     from .chatterbox import ChatterboxBackend
     from .voxcpm import VoxCPMBackend
+    from .voxtral import VoxtralBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
     register(ChatterboxBackend())
     register(VoxCPMBackend())
+    register(VoxtralBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/voxtral.py
+++ b/backends/voxtral.py
@@ -1,0 +1,144 @@
+"""Voxtral TTS backend via mlx-audio."""
+from __future__ import annotations
+
+import logging
+import types
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.voxtral")
+
+MODEL_ID = "mlx-community/Voxtral-4B-TTS-2603-mlx-bf16"
+NATIVE_SR = 24000
+
+VOICE_PRESETS = (
+    "casual_male",
+    "casual_female",
+    "cheerful_female",
+    "neutral_male",
+    "neutral_female",
+    "fr_male",
+    "fr_female",
+    "es_male",
+    "es_female",
+    "de_male",
+    "de_female",
+    "it_male",
+    "it_female",
+    "pt_male",
+    "pt_female",
+    "nl_male",
+    "nl_female",
+    "ar_male",
+    "hi_male",
+    "hi_female",
+)
+
+_DEFAULT_VOICE_BY_LANG = {
+    "en": "casual_male",
+    "fr": "fr_male",
+    "es": "es_male",
+    "de": "de_male",
+    "it": "it_male",
+    "pt": "pt_male",
+    "nl": "nl_male",
+    "ar": "ar_male",
+    "hi": "hi_male",
+}
+
+_ALLOWED_EXTRAS = {"voice", "temperature", "top_k", "top_p", "max_tokens"}
+
+
+def _audio_to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "tolist"):
+        return np.asarray(audio.tolist(), dtype=np.float32)
+    return np.asarray(audio, dtype=np.float32)
+
+
+class VoxtralBackend(BackendBase):
+    name = "voxtral"
+    display_name = "Voxtral 4B TTS"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.IGNORED
+    supported_langs = ("en", "fr", "es", "de", "it", "pt", "nl", "ar", "hi")
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+
+    def load(self) -> None:
+        def _do():
+            from mlx_audio.tts import load_model
+            log.info("loading %s ...", MODEL_ID)
+            self._model = load_model(MODEL_ID)
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"Voxtral does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        voice = extras.get("voice")
+        if voice is not None and voice not in VOICE_PRESETS:
+            raise ValueError(
+                f"Voxtral voice must be one of {VOICE_PRESETS}; got {voice!r}"
+            )
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=None,
+            extras=_read_only(dict(extras)),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            raise RuntimeError("VoxtralBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"voxtral does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        kwargs = dict(
+            text=text,
+            voice=prepared.extras.get("voice", _DEFAULT_VOICE_BY_LANG[lang]),
+            verbose=False,
+        )
+        for key in ("temperature", "top_k", "top_p", "max_tokens"):
+            if key in prepared.extras:
+                kwargs[key] = prepared.extras[key]
+
+        result = self._model.generate(**kwargs)
+        if isinstance(result, types.GeneratorType):
+            chunks = []
+            sample_rates = set()
+            for gr in result:
+                chunks.append(_audio_to_numpy(gr.audio).reshape(-1))
+                if hasattr(gr, "sample_rate"):
+                    sample_rates.add(gr.sample_rate)
+            if not chunks:
+                raise RuntimeError("Voxtral produced no audio chunks")
+            sr = sample_rates.pop() if len(sample_rates) == 1 else NATIVE_SR
+            return np.concatenate(chunks).astype(np.float32, copy=False), sr
+
+        if hasattr(result, "audio"):
+            sr = getattr(result, "sample_rate", NATIVE_SR)
+            return _audio_to_numpy(result.audio).reshape(-1), sr
+        return _audio_to_numpy(result).reshape(-1), NATIVE_SR

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -14,10 +14,10 @@ def _clean_registry():
     backends.reset_for_tests()
 
 
-def test_register_all_populates_four_backends():
+def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
-        "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5",
+        "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
     }
 
 
@@ -69,6 +69,7 @@ def test_slug_strips_dots():
     assert backends.slug("voxcpm-1.5") == "voxcpm-15"
     assert backends.slug("qwen3-0.6b") == "qwen3-06b"
     assert backends.slug("chatterbox") == "chatterbox"
+    assert backends.slug("voxtral") == "voxtral"
 
 
 def test_prepared_voice_extras_are_readonly():
@@ -221,3 +222,119 @@ def test_voxcpm_synthesize_passes_mxarray_ref_audio_to_model(tmp_path):
     assert isinstance(ref, mx.array), f"ref_audio must be mx.array, got {type(ref).__name__}"
     assert ref.ndim == 1, f"ref_audio must be 1-D, got shape {ref.shape}"
     assert ref.shape[0] > 0
+
+
+def test_voxtral_prepare_ignores_ref_text_and_preserves_extras():
+    from backends.voxtral import VoxtralBackend
+    from backends.base import RefTextPolicy
+
+    backend = VoxtralBackend()
+    assert backend.ref_text_policy is RefTextPolicy.IGNORED
+
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "not used by voxtral",
+        {"voice": "fr_female", "temperature": 0.7},
+    )
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text is None
+    assert prepared.extras["voice"] == "fr_female"
+    assert prepared.extras["temperature"] == 0.7
+
+
+def test_voxtral_validate_extras_rejects_unknown_and_invalid_voice():
+    from backends.voxtral import VoxtralBackend
+
+    backend = VoxtralBackend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"cfg_value": 2.0})
+    with pytest.raises(ValueError, match="voice must be one of"):
+        backend.validate_extras({"voice": "picard"})
+
+
+def test_voxtral_synthesize_uses_language_default_voice():
+    from types import SimpleNamespace
+    import numpy as np
+    from backends.voxtral import VoxtralBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxtralBackend()
+    captured_kwargs = {}
+
+    class _CapturingModel:
+        def generate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(
+                audio=np.full(10, 0.25, dtype=np.float32),
+                sample_rate=24000,
+            )
+
+    backend._model = _CapturingModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    audio, sr = backend.synthesize("bonjour", prepared, lang="fr")
+
+    assert sr == 24000
+    assert captured_kwargs["voice"] == "fr_male"
+    assert captured_kwargs["text"] == "bonjour"
+    assert captured_kwargs["verbose"] is False
+    assert audio.shape == (10,)
+    assert np.allclose(audio, 0.25)
+
+
+def test_voxtral_synthesize_uses_voice_extra_and_concatenates_chunks():
+    from types import SimpleNamespace
+    import numpy as np
+    from backends.voxtral import VoxtralBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxtralBackend()
+    captured_kwargs = {}
+
+    class _CapturingModel:
+        def generate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield SimpleNamespace(audio=np.full(4, 0.1, dtype=np.float32))
+            yield SimpleNamespace(audio=np.full(6, 0.2, dtype=np.float32))
+
+    backend._model = _CapturingModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({"voice": "hi_female", "max_tokens": 32}),
+    )
+
+    audio, sr = backend.synthesize("namaste", prepared, lang="hi")
+
+    assert sr == 24000
+    assert captured_kwargs["voice"] == "hi_female"
+    assert captured_kwargs["max_tokens"] == 32
+    assert audio.shape == (10,)
+    assert np.allclose(audio[:4], 0.1)
+    assert np.allclose(audio[4:], 0.2)
+
+
+def test_voxtral_synthesize_raises_on_empty_generator():
+    from backends.voxtral import VoxtralBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = VoxtralBackend()
+
+    class _EmptyModel:
+        def generate(self, **kwargs):
+            return (x for x in ())
+
+    backend._model = _EmptyModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="no audio chunks"):
+        backend.synthesize("hello", prepared, lang="en")

--- a/tests/test_backends_integration.py
+++ b/tests/test_backends_integration.py
@@ -37,6 +37,7 @@ def registered():
     "qwen3-1.7b",
     "chatterbox",
     "voxcpm-1.5",
+    "voxtral",
 ])
 def test_backend_loads_and_synthesizes_short_clip(registered, backend_name):
     b = backends.get(backend_name)


### PR DESCRIPTION
## Summary
- New \`backends/voxtral.py\` wrapping mlx-community/Voxtral-4B-TTS-2603-mlx-bf16 via mlx-audio
- Voxtral is preset-voice driven (not zero-shot), so \`ref_text_policy\` is \`IGNORED\`. Voice presets cover en/fr/es/de/it/pt/nl/ar/hi
- Extras accepted: \`voice\`, \`temperature\`, \`top_k\`, \`top_p\`, \`max_tokens\`; \`validate_extras\` rejects unknown keys + invalid voices
- Closes #5

## Implementation notes
Drafted by codex via Stream B autonomous brief, integrated and tested by claude.

- Model handles both generator and single-result return shapes from mlx-audio
- \`_DEFAULT_VOICE_BY_LANG\` picks a sensible preset per language when caller doesn't specify one
- 5 new unit tests (all mock the model — no GPU/Metal needed for CI)

## Test plan
- [x] \`pytest tests/test_backends.py -k voxtral\` — 5/5 pass
- [x] Existing backend tests unchanged
- [ ] **Live load test** (requires Apple Silicon + mlx-audio): \`python -c \"from mlx_audio.tts import load_model; m = load_model('mlx-community/Voxtral-4B-TTS-2603-mlx-bf16')\"\` — verify model_id resolves
- [ ] End-to-end synth: register a Voxtral test profile, call \`/synthesize?voice=...&lang=en\`
- [ ] Gemini QA pass on the implementation (deferred — quota exhausted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)