### PR TITLE
chore: tidy loose ends — hermes wrapper + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ voices/vixen*
 qa-run.txt
 *-output.log
 pytest-output.log
+setup-output*.log
+
+# Claude Code runtime locks (created by /loop / scheduled tasks)
+.claude/scheduled_tasks.lock
 
 # Skill eval workspace (generated during testing)
 skill/*-workspace/
+
+# Voice WAV backups produced by trim-silence-gaps.py
+voices/*.wav.bak

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ curl http://localhost:7860/health | jq .voices
 
 Integrate with Cursor, Windsurf, shell scripts, web apps — anything that can make an HTTP request.
 
+For CLIs without native completion hooks (e.g. Hermes), use the bundled wrapper to speak any text via the server in one call:
+
+```bash
+bash scripts/hermes-tts.sh "Hello from Hermes" picard   # voice arg is optional
+```
+
+The wrapper checks the server, encodes the text, fetches the WAV, trims the leading 100 ms of model artifact, and plays via `afplay`. Same flow Claude Code's hook uses, just invoked manually.
+
 ## Adding More Voices
 
 ```bash

--- a/scripts/hermes-tts.sh
+++ b/scripts/hermes-tts.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Afterwords TTS wrapper for Hermes
+# Direct HTTP call to local Afterwords server
+
+set -e
+
+TEXT="${1:-Hello from Hermes}"
+VOICE="${2:-}"  # Optional: specific voice name
+AFTERWORDS_URL="http://127.0.0.1:7860"
+
+# Check if Afterwords server is running
+if ! curl -s --max-time 2 "${AFTERWORDS_URL}/health" >/dev/null 2>&1; then
+    echo "⚠️  Afterwords server not running at ${AFTERWORDS_URL}" >&2
+    echo "Start with: cd ~/repos/afterwords && python server.py" >&2
+    exit 1
+fi
+
+# URL encode the text
+ENCODED=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$TEXT" 2>/dev/null || echo "$TEXT")
+
+# Build URL with optional voice
+URL="${AFTERWORDS_URL}/synthesize?text=${ENCODED}"
+if [ -n "$VOICE" ]; then
+    URL="${URL}&voice=${VOICE}"
+fi
+
+# Fetch and play
+WAVFILE="/tmp/hermes-afterwords-$$.wav"
+if curl -s --max-time 90 "$URL" -o "$WAVFILE" 2>/dev/null; then
+    FILESIZE=$(stat -f%z "$WAVFILE" 2>/dev/null || echo 0)
+    if [ "$FILESIZE" -gt 1000 ]; then
+        # Trim silence like the original hook does
+        TRIMMED="/tmp/hermes-afterwords-trimmed-$$.wav"
+        if ffmpeg -y -ss 0.1 -i "$WAVFILE" -c copy "$TRIMMED" 2>/dev/null; then
+            mv "$TRIMMED" "$WAVFILE"
+        fi
+        rm -f "$TRIMMED"
+
+        # Play audio (afplay is macOS default)
+        afplay "$WAVFILE" 2>/dev/null || echo "Audio saved to $WAVFILE (could not play)"
+        rm -f "$WAVFILE"
+        exit 0
+    fi
+fi
+
+rm -f "$WAVFILE"
+echo "⚠️  TTS generation failed" >&2
+exit 1


### PR DESCRIPTION
## Summary
Cleanup pass after the multi-PR session. Closes the "hermes can't TTS" gap by shipping a wrapper script any tool can shell out to.

- New \`scripts/hermes-tts.sh\` — one-shot TTS for CLIs without native hooks; documented under "Without Claude Code" with a Hermes example
- \`.gitignore\`: \`setup-output*.log\`, \`.claude/scheduled_tasks.lock\`, \`voices/*.wav.bak\`

## Test plan
- [x] \`bash scripts/hermes-tts.sh "test"\` plays via afplay (manual)
- [x] \`git status\` clean of untracked log/lock artifacts after .gitignore takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)