### PR TITLE
docs+setup: surface the Codex CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Claude Code has [`/voice`](https://docs.anthropic.com/en/docs/claude-code/voice-
 
 If Claude Code isn't installed, setup will offer to install it (requires Node.js; setup installs that too if needed via Homebrew).
 
+## With Codex CLI
+
+Codex CLI (`@openai/codex`) doesn't expose a Stop-hook event the way Claude Code does, so the integration uses a watcher instead: `tail -F` on the active session JSONL under `~/.codex/sessions`, extract final assistant answers, queue them for synthesis. Inside an interactive Codex session (where `$CODEX_THREAD_ID` is set):
+
+```bash
+afterwords codex-hook start    # daemon follows this session, speaks final answers
+afterwords codex-hook status   # check
+afterwords codex-hook stop
+```
+
+The watcher needs `ripgrep` (`brew install ripgrep`) to locate the session file. Setup auto-detects Codex and prints these commands when it finishes; you don't have to memorize them.
+
+Trade-offs vs Claude Code: this depends on Codex's local session file format and on `$CODEX_THREAD_ID` being exported, both undocumented contracts that may shift between Codex versions. For non-interactive Codex (`codex exec`), prefer wrapping with `--output-last-message <FILE>` and feeding the file to `/synthesize` directly — cleaner and version-stable.
+
 ## Without Claude Code
 
 The TTS server is a plain HTTP API. Use it from any tool, script, or application:

--- a/setup.sh
+++ b/setup.sh
@@ -648,4 +648,28 @@ else
     echo
     echo -e "  ${DIM}To add Claude Code integration later: re-run${NC} ${CYAN}bash setup.sh${NC}"
 fi
+
+# ── Codex CLI discovery (optional, per-session) ─────────────────
+if command -v codex &>/dev/null; then
+    echo
+    rule
+    echo
+    echo -e "  ${BOLD}Codex CLI detected.${NC}"
+    echo -e "  Afterwords ships a watcher that speaks final Codex responses."
+    echo
+    if [ -n "${CODEX_THREAD_ID:-}" ]; then
+        echo -e "  Inside this Codex session, run:"
+        echo -e "    ${CYAN}afterwords codex-hook start${NC}"
+    else
+        echo -e "  Inside an interactive Codex session (where ${DIM}\$CODEX_THREAD_ID${NC} is set), run:"
+        echo -e "    ${CYAN}afterwords codex-hook start${NC}"
+        echo -e "  Then ${CYAN}afterwords codex-hook status${NC} to verify, ${CYAN}stop${NC} to quiet."
+    fi
+    # Validate Codex-specific dependency: ripgrep
+    if ! command -v rg &>/dev/null; then
+        echo
+        warn "ripgrep (rg) not found — required by the Codex watcher. Install via ${CYAN}brew install ripgrep${NC}."
+    fi
+fi
+
 echo


### PR DESCRIPTION
## Summary
The Codex CLI integration shipped sessions ago but the README has zero mentions and \`setup.sh\` doesn't surface it. Operators have to know the magic incantation. Codex's own self-QA pass flagged this as the top gap.

This PR adds discoverability without changing the implementation:

- **\`setup.sh\`**: detects \`codex\` on PATH; prints a "Codex CLI detected" block at the end of setup with the exact start command, plus a ripgrep dependency check (the watcher uses \`rg\` to locate session JSONL files)
- **README**: new "With Codex CLI" section parallel to "With Claude Code"; documents the watcher mechanism, the three CLI subcommands, and is honest about the brittleness (\`CODEX_THREAD_ID\` and \`~/.codex/sessions\` JSONL layout are undocumented Codex contracts)

## Codex's other findings (deferred to follow-ups)
Codex's self-QA also identified structural gaps in the integration itself, all out-of-scope for this docs/setup PR:

- **Global, not per-session**: \`/tmp/codex-tts-*.{pid,txt}\` paths mean only one watcher across all repos — collision waiting to happen
- **Queue race conditions**: unlocked appends + worker rewrites = lost lines possible
- **Tab-delimited corruption**: tabs in \`PROJECT_DIR\`, \`AGENT_TYPE\`, or response text break parsing
- **No URL encoding for voice names** from \`.afterwords\`
- **\`AGENT_TYPE\` unused by codex watcher** — per-agent voice mapping is silently dead for Codex sessions
- **Cleaner alternative for \`codex exec\`**: \`--output-last-message <FILE>\` is more stable than tailing JSONL

These will go on a separate hardening issue I'll file alongside this PR.

## Test plan
- [x] \`bash -n setup.sh\` clean
- [ ] Re-run \`setup.sh\` on a fresh checkout with \`codex\` on PATH — verify the discovery block appears
- [ ] Re-run with \`codex\` absent — verify no spurious output

🤖 Generated with [Claude Code](https://claude.com/claude-code)