### PR TITLE
feat: Gemini CLI integration via adapter shim (closes #36)

### DIFF
--- a/.claude/hooks/gemini-tts-hook.sh
+++ b/.claude/hooks/gemini-tts-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Queue a Gemini CLI assistant response for Afterwords TTS.
+#
+# Gemini fires AfterAgent (analogue of Claude Stop) with a JSON payload that
+# differs from Claude's: it sends `.prompt_response` rather than
+# `.last_assistant_message`, and `.hook_event_name` instead of agent_type. This
+# adapter normalises and re-emits in the format the existing Claude TTS hook +
+# worker already understand, then reuses the same /tmp/claude-tts-queue.txt and
+# /tmp/claude-tts-worker.pid so a single worker drains both sources.
+#
+# Wire-up: drop this in ~/.claude/hooks/ (or wherever your Claude tts-hook.sh
+# lives) and reference it from ~/.gemini/settings.json. See README "With Gemini
+# CLI" for the JSON snippet.
+set -uo pipefail
+
+QUEUE="/tmp/claude-tts-queue.txt"
+WORKER_PID="/tmp/claude-tts-worker.pid"
+WORKER="$HOME/.claude/hooks/tts-worker.sh"
+STRIP_MARKDOWN="$HOME/.claude/hooks/strip-markdown.py"
+
+INPUT=$(cat)
+[ -z "$INPUT" ] && exit 0
+
+# Gemini sends prompt_response. Fall back to last_assistant_message in case the
+# Gemini schema converges with Claude's in a future release.
+TEXT=$(printf '%s' "$INPUT" | jq -r '.prompt_response // .last_assistant_message // empty' 2>/dev/null \
+    | python3 "$STRIP_MARKDOWN" 2>/dev/null)
+[ -z "$TEXT" ] && exit 0
+
+# Gemini hook payload doesn't carry an agent_type; subagent semantics differ
+# enough that we don't try to map them. Per-agent voice override via
+# .afterwords mapping is therefore Claude-only for now.
+AGENT=""
+
+# Queue format: CWD<tab>AGENT<tab>TEXT — same as Claude's tts-hook.sh
+printf '%s\t%s\t%s\n' "$PWD" "$AGENT" "$TEXT" >> "$QUEUE"
+
+if [ -f "$WORKER_PID" ]; then
+    EXISTING=$(cat "$WORKER_PID" 2>/dev/null)
+    if [ -n "$EXISTING" ] && kill -0 "$EXISTING" 2>/dev/null; then
+        exit 0
+    fi
+    rm -f "$WORKER_PID"
+fi
+
+nohup bash "$WORKER" >/dev/null 2>&1 &

--- a/README.md
+++ b/README.md
@@ -42,6 +42,37 @@ The watcher needs `ripgrep` (`brew install ripgrep`) to locate the session file.
 
 Trade-offs vs Claude Code: this depends on Codex's local session file format and on `$CODEX_THREAD_ID` being exported, both undocumented contracts that may shift between Codex versions. For non-interactive Codex (`codex exec`), prefer wrapping with `--output-last-message <FILE>` and feeding the file to `/synthesize` directly — cleaner and version-stable.
 
+## With Gemini CLI
+
+Gemini CLI ships hook support, including a `gemini hooks migrate --from-claude` subcommand. Tempting — but in our testing it has a silent-write bug: when run from `$HOME` it reports success but leaves `~/.gemini/settings.json` unchanged (it writes via `setValue("Workspace", ...)` which is read-only when cwd == home). Even when the migrate succeeds elsewhere, the resulting config wouldn't work for TTS because the **payload schema differs**: Claude sends `last_assistant_message`, Gemini sends `prompt_response`.
+
+So we ship a small adapter instead. `setup.sh` installs `~/.claude/hooks/gemini-tts-hook.sh` (it normalises `prompt_response` → the existing Claude tts-hook + worker chain) and prints the JSON snippet to add to `~/.gemini/settings.json`:
+
+```json
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/gemini-tts-hook.sh",
+            "timeout": 120000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Two things to know:
+
+- Gemini fires `AfterAgent` (analogue of Claude's `Stop`); there's no clean `SubagentStop` analogue, so per-agent voice mapping via `.afterwords` is Claude-only for now.
+- The adapter reuses Claude's TTS queue (`/tmp/claude-tts-queue.txt`) and worker, so a single Afterwords worker drains both Claude and Gemini sessions. No coordination needed.
+
+Test: `gemini -p "say hi"` should speak the response via Afterwords using your default voice.
+
 ## Without Claude Code
 
 The TTS server is a plain HTTP API. Use it from any tool, script, or application:

--- a/setup.sh
+++ b/setup.sh
@@ -672,4 +672,43 @@ if command -v codex &>/dev/null; then
     fi
 fi
 
+# ── Gemini CLI discovery (manual config; gemini hooks migrate is buggy) ────
+if command -v gemini &>/dev/null && $HAS_CLAUDE; then
+    GEMINI_HOOK_DEST="$HOME/.claude/hooks/gemini-tts-hook.sh"
+    GEMINI_SETTINGS="$HOME/.gemini/settings.json"
+    echo
+    rule
+    echo
+    echo -e "  ${BOLD}Gemini CLI detected.${NC}"
+    if [ ! -f "$GEMINI_HOOK_DEST" ]; then
+        cp "$SCRIPT_DIR/.claude/hooks/gemini-tts-hook.sh" "$GEMINI_HOOK_DEST" 2>/dev/null && \
+            chmod +x "$GEMINI_HOOK_DEST" 2>/dev/null
+        ok "installed gemini-tts-hook.sh adapter to ~/.claude/hooks/"
+    fi
+    echo
+    echo -e "  Gemini's hook payload differs from Claude's, and ${CYAN}gemini hooks migrate${NC} has a"
+    echo -e "  silent-write bug when run from \$HOME. Add this snippet to ${DIM}${GEMINI_SETTINGS}${NC}"
+    echo -e "  manually (merging with any existing keys):"
+    echo
+    cat <<'GEMINI_SNIPPET'
+    {
+      "hooks": {
+        "AfterAgent": [
+          {
+            "hooks": [
+              {
+                "type": "command",
+                "command": "bash ~/.claude/hooks/gemini-tts-hook.sh",
+                "timeout": 120000
+              }
+            ]
+          }
+        ]
+      }
+    }
+GEMINI_SNIPPET
+    echo
+    echo -e "  Test: ${CYAN}gemini -p \"say hi\"${NC} — should speak the response via afterwords."
+fi
+
 echo


### PR DESCRIPTION
## Summary
Wires Gemini CLI to Afterwords TTS via a small adapter shim. Codex's review of the existing investigation found two hard blockers in the obvious "just use \`gemini hooks migrate\`" path:

1. **Silent-write bug** in gemini-cli: when run from \$HOME, migrate calls \`setValue("Workspace", …)\` which silently no-ops because Workspace scope == \`<cwd>/.gemini/settings.json\` and gemini-cli's saveSettings skips that case. Verified by SHA-256 before/after + reading the bundle source.
2. **Schema mismatch**: Claude sends \`.last_assistant_message\`; Gemini sends \`.prompt_response\`. Even if migrate worked, the existing \`tts-hook.sh\` would extract empty text and exit silently.

## What ships
- **\`.claude/hooks/gemini-tts-hook.sh\`** — adapter that reads \`.prompt_response\` (fallback to \`.last_assistant_message\` in case Gemini's schema converges later), strips markdown, and emits to the existing \`/tmp/claude-tts-queue.txt\`. **Single worker drains both Claude and Gemini queues** — no extra coordination.
- **\`setup.sh\`** — detects \`gemini\` on PATH, copies the adapter into \`~/.claude/hooks/\`, prints the manual JSON snippet users add to \`~/.gemini/settings.json\` (migrate is explicitly NOT recommended).
- **\`README\`** — new "With Gemini CLI" section parallel to "With Claude Code" + "With Codex CLI", honest about why migrate doesn't work, exact JSON snippet inline.

## Schema mapping

| Claude | Gemini |
|---|---|
| \`Stop\` event | \`AfterAgent\` event |
| \`SubagentStop\` event | (no clean equivalent — per-agent voice via \`.afterwords\` is Claude-only) |
| \`.last_assistant_message\` | \`.prompt_response\` |
| \`async: true\` | dropped silently by Gemini |

## Test plan
- [x] \`bash -n\` clean on adapter + setup.sh
- [x] Adapter logic isolated test: synthetic \`{"prompt_response": "..."}\` payload extracts text correctly
- [x] Queue line emitted in the format \`tts-worker.sh\` already understands
- [ ] End-to-end: \`gemini -p "say hi"\` after manual config → TTS plays (operator verification)
- [ ] Long Gemini response → no encoding issues with multi-line / markdown / code-fence content

## Out of scope (deferred)
- Per-agent voice mapping for Gemini sessions (Gemini's hook payload doesn't carry agent_type in a clean way)
- Auto-merging the JSON snippet into \`~/.gemini/settings.json\` from setup.sh (would need a JSON-aware merge to preserve existing user keys safely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)