### PR TITLE
chore: fb-reindex tool + OpenGraph drift guard

### DIFF
--- a/scripts/check-og-metadata.py
+++ b/scripts/check-og-metadata.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Verify docs/index.html OpenGraph metadata stays in sync with reality.
+
+Catches the failure mode where the demo site grows or shrinks but og:description
+isn't updated, leading to stale Facebook/Twitter/LinkedIn link previews that
+are technically wrong AND get cached for days. Exits non-zero if a mismatch
+is found, so it's safe to wire into CI.
+
+Checks performed:
+  - og:description claims a voice count that matches the actual gallery size
+  - og:url is canonical (matches the deployed Pages URL)
+  - og:image exists at the claimed path
+  - twitter:card and twitter:image are present
+  - All four <meta property="og:*"> required fields are present
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INDEX = REPO / "docs" / "index.html"
+GALLERY = REPO / "docs" / "audio"
+EXPECTED_OG_URL = "https://adrianwedd.github.io/afterwords/"
+
+# Required OG/Twitter tags. Title and description are checked separately.
+REQUIRED_OG = ("og:title", "og:description", "og:type", "og:url", "og:image")
+REQUIRED_TW = ("twitter:card", "twitter:image")
+
+
+def parse_meta(html: str) -> dict[str, str]:
+    """Extract <meta property|name=...> content into a flat dict."""
+    pattern = re.compile(
+        r'<meta\s+(?:property|name)="([^"]+)"\s+content="([^"]*)"', re.IGNORECASE
+    )
+    return {m.group(1): m.group(2) for m in pattern.finditer(html)}
+
+
+def gallery_voice_count() -> int:
+    return len(list(GALLERY.glob("*.mp3")))
+
+
+def main() -> int:
+    if not INDEX.exists():
+        print(f"error: {INDEX} not found", file=sys.stderr)
+        return 2
+
+    html = INDEX.read_text()
+    meta = parse_meta(html)
+    issues: list[str] = []
+
+    # 1. Required tags present
+    for tag in (*REQUIRED_OG, *REQUIRED_TW):
+        if tag not in meta or not meta[tag].strip():
+            issues.append(f"missing or empty meta: {tag}")
+
+    # 2. Voice count claim in og:description matches gallery
+    desc = meta.get("og:description", "")
+    actual_count = gallery_voice_count()
+    claim_match = re.search(r"(\d+)\s+voices?", desc, re.IGNORECASE)
+    if claim_match:
+        claimed = int(claim_match.group(1))
+        if claimed != actual_count:
+            issues.append(
+                f"og:description claims {claimed} voices but docs/audio/ has {actual_count}"
+            )
+    else:
+        issues.append(
+            "og:description doesn't mention a voice count — "
+            "add 'N voices' so this drift check stays meaningful"
+        )
+
+    # 3. Canonical URL
+    if meta.get("og:url") not in (EXPECTED_OG_URL, EXPECTED_OG_URL.rstrip("/")):
+        issues.append(
+            f"og:url is {meta.get('og:url')!r}, expected {EXPECTED_OG_URL!r}"
+        )
+
+    # 4. og:image points at a file that exists in docs/
+    img_url = meta.get("og:image", "")
+    if img_url:
+        # Strip the deployed prefix to get a repo-relative path
+        relative = img_url.replace(EXPECTED_OG_URL, "")
+        img_path = REPO / "docs" / relative
+        if not img_path.exists():
+            issues.append(
+                f"og:image points to {img_url} but {img_path} not found in repo"
+            )
+
+    # 5. Same-as title — a Twitter card without title is fine if og:title exists,
+    # but flag if og:title and twitter:title both exist and differ.
+    if "twitter:title" in meta and meta["twitter:title"] != meta.get("og:title"):
+        issues.append(
+            f"twitter:title {meta['twitter:title']!r} differs from "
+            f"og:title {meta.get('og:title')!r}"
+        )
+
+    # Output
+    if issues:
+        print(f"OG metadata drift detected ({len(issues)} issue(s)):", file=sys.stderr)
+        for i in issues:
+            print(f"  ✗ {i}", file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            "After fixing, force a Facebook re-scrape so the cached preview updates:",
+            file=sys.stderr,
+        )
+        print("    bash scripts/fb-reindex.sh", file=sys.stderr)
+        return 1
+
+    print(f"✓ OG metadata clean — {actual_count} voices, all required tags present")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fb-reindex.sh
+++ b/scripts/fb-reindex.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Force Facebook to re-scrape (reindex) one or more URLs after their
+# OpenGraph metadata changes. Without an explicit re-scrape, Facebook
+# serves stale link previews until its cache TTL expires (often days).
+#
+# Usage:
+#   bash scripts/fb-reindex.sh                                  # default URLs
+#   bash scripts/fb-reindex.sh https://example.com/page1 ...    # specific URLs
+#
+# Auth:
+#   - Set FB_APP_ID and FB_APP_SECRET in env to use the Graph API directly
+#     (preferred — non-interactive, scriptable in CI).
+#   - Without those, the script prints the manual Sharing Debugger URLs
+#     and exits, so you can click through them.
+#
+# Docs: https://developers.facebook.com/docs/sharing/webmasters/scraping/
+set -uo pipefail
+
+DEFAULT_URLS=(
+    "https://adrianwedd.github.io/afterwords/"
+    "https://github.com/adrianwedd/afterwords"
+)
+
+if [ "$#" -gt 0 ]; then
+    URLS=("$@")
+else
+    URLS=("${DEFAULT_URLS[@]}")
+fi
+
+# ANSI
+GRN="\033[0;32m"; YLW="\033[0;33m"; RED="\033[0;31m"; DIM="\033[2m"; NC="\033[0m"
+
+# If FB_APP_ID + FB_APP_SECRET are present, mint an app access token and call
+# the Graph API. Otherwise, fall back to printing the manual Debugger URLs.
+TOKEN=""
+if [ -n "${FB_APP_ID:-}" ] && [ -n "${FB_APP_SECRET:-}" ]; then
+    TOKEN_URL="https://graph.facebook.com/oauth/access_token?client_id=${FB_APP_ID}&client_secret=${FB_APP_SECRET}&grant_type=client_credentials"
+    TOKEN=$(curl -sS "$TOKEN_URL" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("access_token",""))
+except: pass' 2>/dev/null)
+    if [ -z "$TOKEN" ]; then
+        echo -e "${YLW}warn:${NC} could not mint FB app access token (check FB_APP_ID/FB_APP_SECRET)"
+    fi
+fi
+
+if [ -z "$TOKEN" ]; then
+    echo -e "${YLW}No FB credentials in env.${NC} Open these URLs in a browser to force re-scrape:"
+    echo
+    for u in "${URLS[@]}"; do
+        # URL-encode for the debugger query
+        ENC=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=''))" "$u")
+        echo -e "  ${DIM}https://developers.facebook.com/tools/debug/?q=${ENC}${NC}"
+    done
+    echo
+    echo -e "  Click ${DIM}\"Scrape Again\"${NC} on each. Or set FB_APP_ID + FB_APP_SECRET to do it from the CLI."
+    exit 0
+fi
+
+# Have a token — call the Graph API for each URL
+FAILED=0
+for u in "${URLS[@]}"; do
+    RESPONSE=$(curl -sS -X POST \
+        -F "id=${u}" \
+        -F "scrape=true" \
+        -F "access_token=${TOKEN}" \
+        "https://graph.facebook.com/v19.0/")
+    SUCCESS=$(printf '%s' "$RESPONSE" | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)
+    print("ok" if "url" in d and "error" not in d else "fail")
+except: print("fail")' 2>/dev/null)
+    if [ "$SUCCESS" = "ok" ]; then
+        echo -e "  ${GRN}✓${NC} re-scraped: $u"
+    else
+        echo -e "  ${RED}✗${NC} failed:    $u"
+        echo -e "    ${DIM}${RESPONSE:0:200}${NC}"
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+exit "$FAILED"

--- a/tests/test_og_metadata.py
+++ b/tests/test_og_metadata.py
@@ -1,0 +1,28 @@
+"""Guard rail: OpenGraph metadata on docs/index.html stays in sync with reality.
+
+If og:description claims "20 voices" but docs/audio/ has 25, Facebook caches
+the wrong preview for days. This test fails fast so the operator catches drift
+before pushing.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "check-og-metadata.py"
+
+
+def test_og_metadata_in_sync_with_demo_gallery():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"OG metadata drift detected — fix docs/index.html:\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary
Two complementary pieces:

1. **\`scripts/fb-reindex.sh\`** — forces Facebook to re-scrape a URL so stale link previews update. With \`FB_APP_ID\`+\`FB_APP_SECRET\` in env it uses the Graph API directly; without them it prints the manual Sharing Debugger URLs.
2. **\`scripts/check-og-metadata.py\` + \`tests/test_og_metadata.py\`** — catches the drift that necessitates the re-scrape. Verifies \`og:description\`'s voice count claim matches the actual demo gallery, plus presence/canonicality of all required OG + Twitter tags.

Currently the og:description says "20 voices" and \`docs/audio/\` has 20 MP3s — so the check passes. The drift would happen the next time the gallery grows (Doctor Who 15-voice batch, future additions) and someone forgets the metadata. The test fails that PR until they fix it.

## Test plan
- [x] \`pytest tests/test_og_metadata.py\` passes against current state
- [x] \`bash scripts/fb-reindex.sh\` (no token) prints both Sharing Debugger URLs
- [ ] On the operator's machine: open the printed Debugger URLs and click "Scrape Again" — confirm preview refresh
- [ ] Future PR that adds voices without updating og:description → \`pytest\` catches it

## Long-form follow-up
Once a real GitHub Actions workflow exists, wire \`scripts/check-og-metadata.py\` into a deploy gate. For now, the pytest test runs on every operator-driven \`pytest\` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)