### PR TITLE
feat: add OpenVoice v2 backend (zero-shot multilingual cloning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across four MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5).
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -164,7 +164,7 @@ afterwords reload   # rescans voices/, adds new profiles, no synthesis interrupt
 
 ## Languages
 
-The four backends advertise different language support. Ask `/health` to see what each one offers:
+The backends advertise different language support. Ask `/health` to see what each one offers:
 
 ```bash
 curl -s localhost:7860/health | jq '.loaded_backends | to_entries[] | {backend: .key, langs: .value.supported_langs}'
@@ -197,7 +197,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 │  Your Mac (Apple Silicon, 16 GB+)                          │
 │                                                             │
 │  ┌─────────────────────────┐                                │
-│  │  Multi-Backend TTS      │  ← Four MLX backends, ~10 GB   │
+│  │  Multi-Backend TTS      │  ← MLX + optional OpenVoice     │
 │  │  localhost:7860          │  ← 50+ voice profiles          │
 │  │  /synthesize?text=...    │  ← ~20s per sentence (Qwen3)   │
 │  └─────────┬───────────────┘                                │
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. Four MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), and VoxCPM 1.5 (ModelBest, en/zh). They run on [MLX](https://github.com/ml-explore/mlx) — Apple's ML framework — and preload at startup (~10 GB total).
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko.
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -232,6 +232,9 @@ FastAPI + Uvicorn serving WAV audio over HTTP. Backends load once at startup; ea
 GET  /health
        → {"status":"ok", "ready":true, "voices":[...],
           "loaded_backends": {"qwen3-0.6b": {"loaded":true, "voice_count":..., "supported_langs":[...]}, ...}}
+
+       Current backend ids:
+       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)
@@ -423,6 +426,7 @@ On 32 GB M3 Max (four backends preloaded):
 
 - [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS) by Alibaba (Apache 2.0)
 - [mlx-audio](https://github.com/Blaizzy/mlx-audio) by Blaizzy
+- [OpenVoice](https://github.com/myshell-ai/OpenVoice) and [MeloTTS](https://github.com/myshell-ai/MeloTTS) by MyShell (MIT)
 - [MLX](https://github.com/ml-explore/mlx) by Apple
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/) by Anthropic
 - Voice reference clips used under fair use for personal voice synthesis research

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -32,12 +32,14 @@ def register_all() -> None:
     from .chatterbox import ChatterboxBackend
     from .voxcpm import VoxCPMBackend
     from .voxtral import VoxtralBackend
+    from .openvoice_v2 import OpenVoiceV2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
     register(ChatterboxBackend())
     register(VoxCPMBackend())
     register(VoxtralBackend())
+    register(OpenVoiceV2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/openvoice_v2.py
+++ b/backends/openvoice_v2.py
@@ -1,0 +1,249 @@
+"""OpenVoice v2 backend via MyShell OpenVoice + MeloTTS."""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.openvoice_v2")
+
+MODEL_ID = "myshell-ai/OpenVoiceV2"
+NATIVE_SR = 22050
+DEFAULT_CHECKPOINT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "openvoice-v2",
+    "checkpoints_v2",
+)
+
+_LANG_CONFIG = {
+    "en": ("EN_NEWEST", "en-newest"),
+    "es": ("ES", "es"),
+    "fr": ("FR", "fr"),
+    "zh": ("ZH", "zh"),
+    "ja": ("JP", "jp"),
+    "ko": ("KR", "kr"),
+}
+
+_ALLOWED_EXTRAS = {"speaker", "speed", "tau", "vad"}
+
+
+def _checkpoint_dir() -> str:
+    return os.environ.get("OPENVOICE_V2_CHECKPOINT_DIR", DEFAULT_CHECKPOINT_DIR)
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("OPENVOICE_DEVICE")
+    if requested:
+        return requested
+    if torch.backends.mps.is_available():
+        return "mps"
+    if torch.cuda.is_available():
+        return "cuda:0"
+    return "cpu"
+
+
+def _speaker_slug(speaker_key: str) -> str:
+    return speaker_key.lower().replace("_", "-")
+
+
+class OpenVoiceV2Backend(BackendBase):
+    name = "openvoice-v2"
+    display_name = "OpenVoice v2"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = tuple(_LANG_CONFIG)
+
+    def __init__(self):
+        super().__init__()
+        self._torch = None
+        self._TTS = None
+        self._se_extractor = None
+        self._tone_color_converter = None
+        self._tts_models: dict[str, object] = {}
+        self._checkpoint_dir = _checkpoint_dir()
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                import torch
+                from melo.api import TTS
+                from openvoice import se_extractor
+                from openvoice.api import ToneColorConverter
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-openvoice.txt"
+                )
+                log.warning("OpenVoice v2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            checkpoint_dir = _checkpoint_dir()
+            converter_dir = os.path.join(checkpoint_dir, "converter")
+            config_path = os.path.join(converter_dir, "config.json")
+            ckpt_path = os.path.join(converter_dir, "checkpoint.pth")
+            if not os.path.exists(config_path) or not os.path.exists(ckpt_path):
+                self._unavailable_reason = (
+                    "OpenVoice v2 checkpoints not found. Download "
+                    f"{MODEL_ID} to {checkpoint_dir!r} or set "
+                    "OPENVOICE_V2_CHECKPOINT_DIR."
+                )
+                log.warning("OpenVoice v2 unavailable: %s", self._unavailable_reason)
+                return
+
+            device = _device(torch)
+            log.info(
+                "loading %s converter from %s on %s ...",
+                MODEL_ID,
+                checkpoint_dir,
+                device,
+            )
+            converter = ToneColorConverter(config_path, device=device)
+            converter.load_ckpt(ckpt_path)
+
+            self._torch = torch
+            self._TTS = TTS
+            self._se_extractor = se_extractor
+            self._tone_color_converter = converter
+            self._checkpoint_dir = checkpoint_dir
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"OpenVoice v2 does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        speaker = extras.get("speaker")
+        if speaker is not None:
+            valid = tuple(sorted({default for _, default in _LANG_CONFIG.values()} | {
+                "en-au", "en-br", "en-default", "en-india", "en-us"
+            }))
+            if speaker not in valid:
+                raise ValueError(f"OpenVoice v2 speaker must be one of {valid}; got {speaker!r}")
+        for key in ("speed", "tau"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"OpenVoice v2 {key} must be numeric; got {value!r}")
+        speed = extras.get("speed")
+        if speed is not None and speed <= 0:
+            raise ValueError(f"OpenVoice v2 speed must be > 0; got {speed!r}")
+        vad = extras.get("vad")
+        if vad is not None and not isinstance(vad, bool):
+            raise ValueError(f"OpenVoice v2 vad must be boolean; got {vad!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if self._tone_color_converter is None or self._se_extractor is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"OpenVoice v2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("OpenVoiceV2Backend.prepare_voice called before load()")
+
+        target_dir = tempfile.mkdtemp(prefix="openvoice-v2-se-")
+        try:
+            target_se, _audio_name = self._se_extractor.get_se(
+                ref_audio_path,
+                self._tone_color_converter,
+                target_dir=target_dir,
+                vad=bool(extras.get("vad", True)),
+            )
+        finally:
+            shutil.rmtree(target_dir, ignore_errors=True)
+        prepared_extras = dict(extras)
+        prepared_extras["target_se"] = target_se
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(prepared_extras),
+        )
+
+    def _tts_for(self, openvoice_lang: str):
+        if openvoice_lang not in self._tts_models:
+            self._tts_models[openvoice_lang] = self._TTS(
+                language=openvoice_lang,
+                device=self._device,
+            )
+        return self._tts_models[openvoice_lang]
+
+    def _speaker_id(self, model, speaker_slug: str):
+        speaker_ids = model.hps.data.spk2id
+        for key, value in speaker_ids.items():
+            if _speaker_slug(key) == speaker_slug:
+                return value
+        if len(speaker_ids) == 1:
+            return next(iter(speaker_ids.values()))
+        raise ValueError(
+            f"OpenVoice v2 MeloTTS model has no speaker {speaker_slug!r}; "
+            f"available: {tuple(speaker_ids)}"
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._tone_color_converter is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"OpenVoice v2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("OpenVoiceV2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"openvoice-v2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        openvoice_lang, default_speaker = _LANG_CONFIG[lang]
+        speaker_slug = str(prepared.extras.get("speaker", default_speaker))
+        source_se_path = os.path.join(
+            self._checkpoint_dir,
+            "base_speakers",
+            "ses",
+            f"{speaker_slug}.pth",
+        )
+        if not os.path.exists(source_se_path):
+            raise RuntimeError(f"OpenVoice v2 source speaker embedding not found: {source_se_path}")
+
+        target_se = prepared.extras.get("target_se")
+        if target_se is None:
+            raise RuntimeError("OpenVoice v2 prepared voice is missing target speaker embedding")
+
+        model = self._tts_for(openvoice_lang)
+        speaker_id = self._speaker_id(model, speaker_slug)
+        source_se = self._torch.load(source_se_path, map_location=self._device)
+        speed = float(prepared.extras.get("speed", 1.0))
+        tau = float(prepared.extras.get("tau", 0.3))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src_path = os.path.join(tmpdir, "base.wav")
+            model.tts_to_file(text, speaker_id, src_path, speed=speed)
+            audio = self._tone_color_converter.convert(
+                audio_src_path=src_path,
+                src_se=source_se,
+                tgt_se=target_se,
+                output_path=None,
+                tau=tau,
+                message="@Afterwords",
+            )
+
+        if audio is None:
+            raise RuntimeError("OpenVoice v2 produced no output")
+        return np.asarray(audio, dtype=np.float32).reshape(-1), NATIVE_SR

--- a/docs/research/tts-backends/openvoice-v2.md
+++ b/docs/research/tts-backends/openvoice-v2.md
@@ -3,21 +3,22 @@
 **Repo:** https://github.com/myshell-ai/OpenVoice
 **License:** MIT
 **Size:** 0.5B, 2.0 GB
-**Sample rate:** 24000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: OpenVoice essentially acts as a timbre filter applied over a base TTS model (like MeloTTS).
+**Sample rate:** 22050 (converter `checkpoints_v2/converter/config.json`)
+**Languages:** English, Spanish, French, Chinese, Japanese, Korean (native v2 support)
+**Apple Silicon path:** PyTorch+MPS/CPU — OpenVoice v2 acts as a tone-color converter applied over a base MeloTTS utterance.
 
 ### Install
 ```bash
 git clone https://github.com/myshell-ai/OpenVoice.git
 cd OpenVoice
 pip install -r requirements.txt
-pip install melo-tts
+pip install git+https://github.com/myshell-ai/MeloTTS.git
+python -m unidic download
 ```
 
 ### Model download
 ```bash
-huggingface-cli download myshell-ai/OpenVoiceV2
+huggingface-cli download myshell-ai/OpenVoiceV2 --local-dir checkpoints_v2
 ```
 Disk: 2.0 GB
 
@@ -47,10 +48,10 @@ tone_color_converter.convert('base.wav', base_se, target_se, 'output.wav')
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class OpenVoiceV2Backend(BackendBase):
-    name = "openvoice_v2"
-    sample_rate = 24000
-    ref_text_policy = RefTextPolicy.IGNORED
-    supported_langs = ("multilingual",)
+    name = "openvoice-v2"
+    sample_rate = 22050
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en", "es", "fr", "zh", "ja", "ko")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
@@ -58,6 +59,8 @@ class OpenVoiceV2Backend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- OpenVoice's architecture separates style/prosody (handled by a base TTS engine like MeloTTS) from tone color (handled by the converter). Thus, `load` must instantiate *two* models. `prepare_voice` should execute `se_extractor.get_se` to pull the reference audio's tone color embedding. In `synthesize`, you will first generate the raw audio using the base TTS and its default speaker embedding, then pass that output through the converter applying the cached target tone color. Ensure intermediate `base.wav` files are either written to memory buffers (like `io.BytesIO`) or temporary files to avoid disk IO bottlenecks.
+- OpenVoice's architecture separates text/prosody (MeloTTS) from tone color (OpenVoice converter). `load` should instantiate the converter from `checkpoints_v2/converter`, while MeloTTS language models can be cached lazily per language to avoid loading every language at server startup. `prepare_voice` should execute `se_extractor.get_se` to pull the reference audio's tone color embedding. In `synthesize`, generate a temporary base utterance with MeloTTS, load the matching `checkpoints_v2/base_speakers/ses/{speaker}.pth` source embedding, then pass the base WAV through `ToneColorConverter.convert(...)` with the cached target embedding.
+- Upstream v2 demo language codes are `EN_NEWEST`, `EN`, `ES`, `FR`, `ZH`, `JP`, and `KR`; Afterwords should expose normal request language tags: `en`, `es`, `fr`, `zh`, `ja`, `ko`.
+- The reference transcript is not required by upstream OpenVoice v2 extraction, so Afterwords should advertise `RefTextPolicy.OPTIONAL`.
 
 ---

--- a/requirements-openvoice.txt
+++ b/requirements-openvoice.txt
@@ -1,0 +1,15 @@
+# Optional OpenVoice v2 backend dependencies.
+#
+# Install these only if you plan to use backend=openvoice-v2 voice profiles:
+#   pip install -r requirements-openvoice.txt
+#   python -m unidic download
+#   huggingface-cli download myshell-ai/OpenVoiceV2 \
+#     --local-dir backends/extras/openvoice-v2/checkpoints_v2
+#
+# The upstream OpenVoice package pins older numpy/librosa/faster-whisper
+# versions in setup.py; keep this isolated from requirements.txt so the default
+# Afterwords install remains MLX-only.
+torch>=2.1
+huggingface_hub>=0.23
+git+https://github.com/myshell-ai/OpenVoice.git
+git+https://github.com/myshell-ai/MeloTTS.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ python-multipart>=0.0.18,<1.0
 uvicorn>=0.42,<1.0
 noisereduce>=3.0,<4.0
 faster-whisper>=1.0,<2.0
+
+# OpenVoice v2 is optional because it brings PyTorch/MeloTTS dependencies that
+# can conflict with the default MLX-only install. See requirements-openvoice.txt.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,6 +18,7 @@ def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
+        "openvoice-v2",
     }
 
 
@@ -338,3 +339,128 @@ def test_voxtral_synthesize_raises_on_empty_generator():
 
     with pytest.raises(RuntimeError, match="no audio chunks"):
         backend.synthesize("hello", prepared, lang="en")
+
+
+def test_openvoice_v2_metadata():
+    from backends.openvoice_v2 import OpenVoiceV2Backend
+
+    backend = OpenVoiceV2Backend()
+
+    assert backend.name == "openvoice-v2"
+    assert backend.display_name == "OpenVoice v2"
+    assert backend.sample_rate == 22050
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en", "es", "fr", "zh", "ja", "ko")
+
+
+def test_openvoice_v2_prepare_voice_extracts_target_se(tmp_path):
+    from backends.openvoice_v2 import OpenVoiceV2Backend
+
+    backend = OpenVoiceV2Backend()
+    backend._tone_color_converter = object()
+
+    class _Extractor:
+        def get_se(self, ref_audio_path, converter, target_dir, vad):
+            assert ref_audio_path == "/tmp/ref.wav"
+            assert converter is backend._tone_color_converter
+            assert vad is True
+            assert tmp_path.exists()
+            return "target-se", "ref"
+
+    backend._se_extractor = _Extractor()
+
+    prepared = backend.prepare_voice("/tmp/ref.wav", "reference text", {})
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference text"
+    assert prepared.extras["target_se"] == "target-se"
+
+
+def test_openvoice_v2_synthesize_raises_before_load():
+    from backends.openvoice_v2 import OpenVoiceV2Backend
+
+    backend = OpenVoiceV2Backend()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="called before load"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_openvoice_v2_synthesize_rejects_unsupported_language():
+    from backends.openvoice_v2 import OpenVoiceV2Backend
+
+    backend = OpenVoiceV2Backend()
+    backend._tone_color_converter = object()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({"target_se": "target-se"}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='de'"):
+        backend.synthesize("hallo", prepared, lang="de")
+
+
+def test_openvoice_v2_synthesize_uses_melo_and_converter(tmp_path):
+    import numpy as np
+    from types import SimpleNamespace
+    from backends.openvoice_v2 import OpenVoiceV2Backend
+
+    backend = OpenVoiceV2Backend()
+    checkpoint_dir = tmp_path / "checkpoints_v2"
+    se_dir = checkpoint_dir / "base_speakers" / "ses"
+    se_dir.mkdir(parents=True)
+    (se_dir / "en-newest.pth").write_bytes(b"stub")
+    backend._checkpoint_dir = str(checkpoint_dir)
+    backend._device = "cpu"
+
+    captured_tts = {}
+    captured_convert = {}
+
+    class _Torch:
+        def load(self, path, map_location):
+            assert path == str(se_dir / "en-newest.pth")
+            assert map_location == "cpu"
+            return "source-se"
+
+    class _TTSModel:
+        hps = SimpleNamespace(data=SimpleNamespace(spk2id={"EN-Newest": 7}))
+
+        def tts_to_file(self, text, speaker_id, output_path, speed):
+            captured_tts.update(
+                text=text,
+                speaker_id=speaker_id,
+                output_path=output_path,
+                speed=speed,
+            )
+            with open(output_path, "wb") as f:
+                f.write(b"RIFF")
+
+    class _Converter:
+        def convert(self, **kwargs):
+            captured_convert.update(kwargs)
+            return np.array([0.1, -0.2], dtype=np.float32)
+
+    backend._torch = _Torch()
+    backend._tone_color_converter = _Converter()
+    backend._tts_models["EN_NEWEST"] = _TTSModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({"target_se": "target-se", "speed": 1.2, "tau": 0.4}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 22050
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured_tts["text"] == "hello"
+    assert captured_tts["speaker_id"] == 7
+    assert captured_tts["speed"] == 1.2
+    assert captured_convert["src_se"] == "source-se"
+    assert captured_convert["tgt_se"] == "target-se"
+    assert captured_convert["tau"] == 0.4


### PR DESCRIPTION
## Summary
- Add an optional OpenVoice v2 backend using the upstream MeloTTS base utterance plus ToneColorConverter flow.
- Register `openvoice-v2` with 22.05 kHz output, optional reference text, and native v2 language tags: en/es/fr/zh/ja/ko.
- Keep OpenVoice/MeloTTS imports and checkpoint loading out of package import time; missing optional deps or checkpoints mark the backend unavailable without breaking default MLX-only installs.
- Add mocked unit tests and document isolated OpenVoice dependencies in `requirements-openvoice.txt`.
- Refresh `docs/research/tts-backends/openvoice-v2.md` with verified upstream sample rate, language mapping, and install notes.

## Testing
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`
- `PYTHONPATH=. .venv/bin/python -m pytest tests/ -k "not test_voxcpm_synthesize_handles_generator_output"`

## Dependency notes
OpenVoice upstream currently installs from GitHub and pins older transitive dependencies in its setup metadata. This PR keeps those dependencies isolated in `requirements-openvoice.txt` so the normal Afterwords install remains unchanged.