### PR TITLE
feat: add F5-TTS backend (flow-matching DiT, CC-BY-NC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2 and F5-TTS.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use.
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -234,7 +234,7 @@ GET  /health
           "loaded_backends": {"qwen3-0.6b": {"loaded":true, "voice_count":..., "supported_langs":[...]}, ...}}
 
        Current backend ids:
-       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2
+       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -33,6 +33,7 @@ def register_all() -> None:
     from .voxcpm import VoxCPMBackend
     from .voxtral import VoxtralBackend
     from .openvoice_v2 import OpenVoiceV2Backend
+    from .f5_tts import F5TTSBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -40,6 +41,7 @@ def register_all() -> None:
     register(VoxCPMBackend())
     register(VoxtralBackend())
     register(OpenVoiceV2Backend())
+    register(F5TTSBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/f5_tts.py
+++ b/backends/f5_tts.py
@@ -1,0 +1,173 @@
+"""F5-TTS backend via SWivid F5-TTS.
+
+F5-TTS uses a flow-matching Diffusion Transformer (DiT) backbone. Upstream
+code is MIT licensed, but the default pretrained F5-TTS model weights are
+CC-BY-NC 4.0 due to the Emilia training data, so this backend is not suitable
+for commercial use unless you configure different weights with a compatible
+license.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.f5_tts")
+
+MODEL_ID = "SWivid/F5-TTS/F5TTS_v1_Base"
+NATIVE_SR = 24000
+
+_ALLOWED_EXTRAS = {
+    "target_rms",
+    "cross_fade_duration",
+    "sway_sampling_coef",
+    "cfg_strength",
+    "nfe_step",
+    "speed",
+    "fix_duration",
+    "seed",
+}
+
+_FLOAT_EXTRAS = {
+    "target_rms",
+    "cross_fade_duration",
+    "sway_sampling_coef",
+    "cfg_strength",
+    "speed",
+    "fix_duration",
+}
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("F5TTS_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if getattr(torch, "xpu", None) is not None and torch.xpu.is_available():
+        return "xpu"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+class F5TTSBackend(BackendBase):
+    name = "f5-tts"
+    display_name = "F5-TTS v1 Base (DiT, CC-BY-NC)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.REQUIRED
+    supported_langs = ("en", "zh")
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from f5_tts.api import F5TTS
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-f5tts.txt"
+                )
+                log.warning("F5-TTS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            device = _device(torch)
+            model = os.environ.get("F5TTS_MODEL", "F5TTS_v1_Base")
+            hf_cache_dir = os.environ.get("F5TTS_HF_CACHE_DIR") or None
+            log.info("loading %s on %s ...", model, device)
+            self._model = F5TTS(model=model, device=device, hf_cache_dir=hf_cache_dir)
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"F5-TTS does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in _FLOAT_EXTRAS:
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"F5-TTS {key} must be numeric; got {value!r}")
+        for key in ("nfe_step", "seed"):
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"F5-TTS {key} must be an integer; got {value!r}")
+        if extras.get("nfe_step") is not None and extras["nfe_step"] <= 0:
+            raise ValueError(f"F5-TTS nfe_step must be > 0; got {extras['nfe_step']!r}")
+        if extras.get("speed") is not None and extras["speed"] <= 0:
+            raise ValueError(f"F5-TTS speed must be > 0; got {extras['speed']!r}")
+        if extras.get("target_rms") is not None and extras["target_rms"] <= 0:
+            raise ValueError(f"F5-TTS target_rms must be > 0; got {extras['target_rms']!r}")
+        if extras.get("cross_fade_duration") is not None and extras["cross_fade_duration"] < 0:
+            raise ValueError(
+                "F5-TTS cross_fade_duration must be >= 0; "
+                f"got {extras['cross_fade_duration']!r}"
+            )
+        if extras.get("cfg_strength") is not None and extras["cfg_strength"] <= 0:
+            raise ValueError(f"F5-TTS cfg_strength must be > 0; got {extras['cfg_strength']!r}")
+        if extras.get("fix_duration") is not None and extras["fix_duration"] <= 0:
+            raise ValueError(f"F5-TTS fix_duration must be > 0; got {extras['fix_duration']!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if not ref_text or not ref_text.strip():
+            raise ValueError("F5-TTS requires reference_text for reliable voice alignment")
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text.strip(),
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"F5-TTS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("F5TTSBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"f5-tts does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+        if not prepared.ref_text:
+            raise RuntimeError("F5-TTS prepared voice is missing reference_text")
+
+        kwargs = {
+            "ref_file": prepared.ref_audio_path,
+            "ref_text": prepared.ref_text,
+            "gen_text": text,
+            "show_info": log.debug,
+            "progress": None,
+        }
+        for key in _ALLOWED_EXTRAS:
+            if key in prepared.extras:
+                kwargs[key] = prepared.extras[key]
+
+        wav, sr, _spec = self._model.infer(**kwargs)
+        if wav is None:
+            raise RuntimeError("F5-TTS produced no output")
+        return np.asarray(wav, dtype=np.float32).reshape(-1), int(sr)

--- a/docs/research/tts-backends/f5-tts.md
+++ b/docs/research/tts-backends/f5-tts.md
@@ -1,11 +1,11 @@
 ## F5-TTS
 
 **Repo:** https://github.com/SWivid/F5-TTS
-**License:** CC-BY-NC 4.0
+**License:** Code is MIT; the default pretrained SWivid/F5-TTS model weights are CC-BY-NC 4.0 and block commercial use.
 **Size:** 0.336B, 1.2 GB
 **Sample rate:** 24000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: MPS is fully supported, and the flow-matching DiT architecture runs very fast on M-series chips.
+**Languages:** `F5TTS_v1_Base` is zh/en. Upstream `SHARED.md` lists community checkpoints for additional languages with their own licenses.
+**Apple Silicon path:** PyTorch+MPS — upstream enables `PYTORCH_ENABLE_MPS_FALLBACK=1`; some ops may fall back from MPS.
 
 ### Install
 ```bash
@@ -13,36 +13,36 @@ pip install f5-tts torch torchaudio
 ```
 
 ### Model download
+Pip installs can auto-fetch from Hugging Face on first load. To prefetch manually:
+
 ```bash
-huggingface-cli download SWivid/F5-TTS
+huggingface-cli download SWivid/F5-TTS --include 'F5TTS_v1_Base/*'
 ```
 Disk: 1.2 GB
 
 ### Python API for cloning
 ```python
-from f5_tts.infer.utils_infer import infer_process
-from f5_tts.model import DiT
+from f5_tts.api import F5TTS
 
-# Assuming models are downloaded to default cache paths
-audio_out, sample_rate, spect = infer_process(
-    ref_audio="reference.wav",
+# Auto-downloads the default F5TTS_v1_Base checkpoint if absent.
+f5tts = F5TTS(model="F5TTS_v1_Base", device="mps")
+audio_out, sample_rate, spect = f5tts.infer(
+    ref_file="reference.wav",
     ref_text="Transcript of reference.",
     gen_text="This is a test sentence.",
-    model_obj=DiT(),
-    vocoder=None
 )
 ```
 
 ### Backend protocol skeleton
 ```python
-# backends/f5tts.py
+# backends/f5_tts.py
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class F5TTSBackend(BackendBase):
-    name = "f5_tts"
+    name = "f5-tts"
     sample_rate = 24000
     ref_text_policy = RefTextPolicy.REQUIRED
-    supported_langs = ("multilingual",)
+    supported_langs = ("en", "zh")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
@@ -50,6 +50,8 @@ class F5TTSBackend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- F5-TTS utilizes a flow-matching and Diffusion Transformer (DiT) backbone, heavily relying on the cross-attention between `ref_text` and `ref_audio`. For the afterwords backend, the `prepare_voice` method must store both the reference WAV and its transcription. One quirk to test first is adjusting the ODE solver's `nfe_step` parameter (number of function evaluations); lowering it speeds up MPS generation drastically, but you'll need to strike the right balance between inference speed and output audio clarity.
+- F5-TTS utilizes a flow-matching and Diffusion Transformer (DiT) backbone, heavily relying on the alignment between `ref_text` and `ref_audio`. Upstream can transcribe when `ref_text` is empty, but that costs extra memory and makes voice profiles less deterministic. For Afterwords, require `reference_text` and store both the reference WAV and its transcription.
+- Useful inference extras to expose: `nfe_step`, `cfg_strength`, `sway_sampling_coef`, `speed`, `target_rms`, `cross_fade_duration`, `fix_duration`, and `seed`. Lowering `nfe_step` can speed up MPS generation, with an audio-quality tradeoff.
+- Keep F5-TTS optional. It is a PyTorch dependency stack, not part of the default MLX-only install, and the default pretrained weights are CC-BY-NC 4.0.
 
 ---

--- a/requirements-f5tts.txt
+++ b/requirements-f5tts.txt
@@ -1,0 +1,12 @@
+# Optional F5-TTS backend dependencies.
+#
+# Install these only if you plan to use backend=f5-tts voice profiles:
+#   pip install -r requirements-f5tts.txt
+#
+# F5-TTS code is MIT licensed, but the default SWivid/F5-TTS pretrained
+# F5TTS_v1_Base weights are CC-BY-NC 4.0 and block commercial use.
+# Keep this isolated from requirements.txt so the default Afterwords install
+# remains MLX-only.
+torch>=2.0
+torchaudio>=2.0
+f5-tts>=1.1.20

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,7 +18,7 @@ def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
-        "openvoice-v2",
+        "openvoice-v2", "f5-tts",
     }
 
 
@@ -464,3 +464,100 @@ def test_openvoice_v2_synthesize_uses_melo_and_converter(tmp_path):
     assert captured_convert["src_se"] == "source-se"
     assert captured_convert["tgt_se"] == "target-se"
     assert captured_convert["tau"] == 0.4
+
+
+def test_f5_tts_metadata():
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+
+    assert backend.name == "f5-tts"
+    assert backend.display_name == "F5-TTS v1 Base (DiT, CC-BY-NC)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.REQUIRED
+    assert backend.supported_langs == ("en", "zh")
+
+
+def test_f5_tts_prepare_voice_requires_ref_text():
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+
+    with pytest.raises(ValueError, match="requires reference_text"):
+        backend.prepare_voice("/tmp/ref.wav", "", {})
+
+
+def test_f5_tts_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"emotion": "happy"})
+    with pytest.raises(ValueError, match="nfe_step must be > 0"):
+        backend.validate_extras({"nfe_step": 0})
+    with pytest.raises(ValueError, match="speed must be > 0"):
+        backend.validate_extras({"speed": -1})
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        backend.validate_extras({"seed": 1.5})
+
+
+def test_f5_tts_synthesize_raises_before_load():
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="called before load"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_f5_tts_synthesize_rejects_unsupported_language():
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+    backend._model = object()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='fr'"):
+        backend.synthesize("bonjour", prepared, lang="fr")
+
+
+def test_f5_tts_synthesize_uses_f5_api_and_generation_extras():
+    import numpy as np
+    from backends.f5_tts import F5TTSBackend
+
+    backend = F5TTSBackend()
+    captured_kwargs = {}
+
+    class _F5Model:
+        def infer(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return np.array([0.3, -0.1], dtype=np.float32), 24000, "spectrogram"
+
+    backend._model = _F5Model()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({"nfe_step": 16, "speed": 1.1, "seed": 123}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert np.allclose(audio, [0.3, -0.1])
+    assert captured_kwargs["ref_file"] == "/tmp/ref.wav"
+    assert captured_kwargs["ref_text"] == "reference text"
+    assert captured_kwargs["gen_text"] == "hello"
+    assert captured_kwargs["nfe_step"] == 16
+    assert captured_kwargs["speed"] == 1.1
+    assert captured_kwargs["seed"] == 123
+    assert captured_kwargs["progress"] is None


### PR DESCRIPTION
## Summary

- Add an optional `f5-tts` backend using upstream SWivid F5-TTS `F5TTS_v1_Base` through lazy PyTorch imports.
- Register the backend after OpenVoice v2 and add mocked backend tests for metadata, validation, ref-text requirements, language rejection, and synthesis dispatch.
- Add optional `requirements-f5tts.txt` and document the CC-BY-NC 4.0 restriction for the default pretrained weights in README and the research note.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`

## Notes

- No model weights were downloaded during implementation or tests.
- Upstream verification corrected the research note: the default `F5TTS_v1_Base` checkpoint is zh/en, while additional languages live in community checkpoints with their own licenses.