### PR TITLE
feat: add CosyVoice2-0.5B backend (Apache-2.0 streaming TTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2 and F5-TTS.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, and CosyVoice2.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,17 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning.
+
+| Backend | License | Languages | Sample rate | Reference text |
+|---------|---------|-----------|-------------|----------------|
+| `qwen3-0.6b`, `qwen3-1.7b` | model-dependent | en/zh/ja/ko/es/fr/de/it/pt/ru | 24 kHz | required |
+| `chatterbox` | model-dependent | en/es/fr/de/it/pt/zh/ja/ko | 24 kHz | optional |
+| `voxcpm-1.5` | model-dependent | en/zh | 44.1 kHz | optional |
+| `voxtral` | model-dependent | preset voices | 24 kHz | ignored |
+| `openvoice-v2` | MIT | en/es/fr/zh/ja/ko | 22.05 kHz | optional |
+| `f5-tts` | CC-BY-NC default weights | en/zh | 24 kHz | required |
+| `cosyvoice2` | Apache-2.0 | en/zh/ja/ko/de/es/fr/it/ru | 24 kHz | required |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -234,7 +244,7 @@ GET  /health
           "loaded_backends": {"qwen3-0.6b": {"loaded":true, "voice_count":..., "supported_langs":[...]}, ...}}
 
        Current backend ids:
-       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts
+       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)
@@ -286,7 +296,7 @@ afterwords/
 ├── server.py             ← multi-voice TTS server
 ├── strip_markdown.py     ← text cleaner for TTS (also used by hooks)
 ├── tests/                ← pytest suite (82+ tests, no GPU needed)
-├── backends/             ← Backend Protocol + 4 concrete backends + registry CLI
+├── backends/             ← Backend Protocol + concrete backends + registry CLI
 ├── scripts/              ← reclone-flagship.py, gen-comparison-audio.sh, audit-voice-transcripts.py, audit-archive.py
 ├── docs/                 ← demo site (deployed to GitHub Pages)
 ├── requirements.txt      ← runtime deps

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -34,6 +34,7 @@ def register_all() -> None:
     from .voxtral import VoxtralBackend
     from .openvoice_v2 import OpenVoiceV2Backend
     from .f5_tts import F5TTSBackend
+    from .cosyvoice2 import CosyVoice2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -42,6 +43,7 @@ def register_all() -> None:
     register(VoxtralBackend())
     register(OpenVoiceV2Backend())
     register(F5TTSBackend())
+    register(CosyVoice2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/cosyvoice2.py
+++ b/backends/cosyvoice2.py
@@ -1,0 +1,152 @@
+"""CosyVoice2-0.5B backend via FunAudioLLM CosyVoice.
+
+CosyVoice upstream code and CosyVoice2-0.5B weights are Apache-2.0 licensed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.cosyvoice2")
+
+MODEL_ID = "FunAudioLLM/CosyVoice2-0.5B"
+NATIVE_SR = 24000
+DEFAULT_MODEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "cosyvoice2",
+    "CosyVoice2-0.5B",
+)
+
+_ALLOWED_EXTRAS = {"speed", "text_frontend"}
+
+
+def _model_dir() -> str:
+    return os.environ.get("COSYVOICE2_MODEL_DIR", DEFAULT_MODEL_DIR)
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+class CosyVoice2Backend(BackendBase):
+    name = "cosyvoice2"
+    display_name = "CosyVoice2-0.5B (Apache-2.0)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.REQUIRED
+    supported_langs = ("en", "zh", "ja", "ko", "de", "es", "fr", "it", "ru")
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._model_dir = _model_dir()
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            model_dir = _model_dir()
+            if not os.path.exists(model_dir):
+                self._unavailable_reason = (
+                    "CosyVoice2 model directory not found. Download "
+                    f"{MODEL_ID} to {model_dir!r} or set COSYVOICE2_MODEL_DIR."
+                )
+                log.warning("CosyVoice2 unavailable: %s", self._unavailable_reason)
+                return
+
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                from cosyvoice.cli.cosyvoice import CosyVoice2
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-cosyvoice2.txt"
+                )
+                log.warning("CosyVoice2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            log.info("loading %s from %s ...", MODEL_ID, model_dir)
+            self._model = CosyVoice2(model_dir)
+            self._model_dir = model_dir
+            self.sample_rate = int(getattr(self._model, "sample_rate", NATIVE_SR))
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"CosyVoice2 does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        speed = extras.get("speed")
+        if speed is not None and not isinstance(speed, (int, float)):
+            raise ValueError(f"CosyVoice2 speed must be numeric; got {speed!r}")
+        if speed is not None and speed <= 0:
+            raise ValueError(f"CosyVoice2 speed must be > 0; got {speed!r}")
+        text_frontend = extras.get("text_frontend")
+        if text_frontend is not None and not isinstance(text_frontend, bool):
+            raise ValueError(f"CosyVoice2 text_frontend must be boolean; got {text_frontend!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if not ref_text or not ref_text.strip():
+            raise ValueError("CosyVoice2 requires reference_text aligned with reference audio")
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text.strip(),
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"CosyVoice2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("CosyVoice2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"cosyvoice2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+        if not prepared.ref_text:
+            raise RuntimeError("CosyVoice2 prepared voice is missing reference_text")
+
+        chunks = []
+        for output in self._model.inference_zero_shot(
+            text,
+            prepared.ref_text,
+            prepared.ref_audio_path,
+            stream=False,
+            speed=float(prepared.extras.get("speed", 1.0)),
+            text_frontend=bool(prepared.extras.get("text_frontend", True)),
+        ):
+            if not isinstance(output, Mapping) or "tts_speech" not in output:
+                raise RuntimeError("CosyVoice2 produced an invalid output chunk")
+            chunks.append(_to_numpy(output["tts_speech"]))
+
+        if not chunks:
+            raise RuntimeError("CosyVoice2 produced no output")
+        audio = chunks[0] if len(chunks) == 1 else np.concatenate(chunks)
+        return audio.astype(np.float32, copy=False), int(getattr(self._model, "sample_rate", NATIVE_SR))

--- a/docs/research/tts-backends/cosyvoice2.md
+++ b/docs/research/tts-backends/cosyvoice2.md
@@ -3,38 +3,36 @@
 **Repo:** https://github.com/FunAudioLLM/CosyVoice
 **License:** Apache-2.0
 **Size:** 0.5B, 2.0 GB
-**Sample rate:** 22050
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: Fully supports MPS, but may require specific ONNX runtime configurations for frontend grapheme-to-phoneme conversion.
+**Sample rate:** 24000
+**Languages:** multilingual (Chinese, English, Japanese, Korean, German, Spanish, French, Italian, Russian)
+**Apple Silicon path:** PyTorch+MPS/CPU fallback — upstream disables CUDA-only acceleration flags when CUDA is unavailable; ONNX frontend/tokenizer sessions run on CPU on macOS.
 
 ### Install
 ```bash
-git clone https://github.com/FunAudioLLM/CosyVoice.git
+git clone --recursive https://github.com/FunAudioLLM/CosyVoice.git
 cd CosyVoice
 pip install -r requirements.txt
-pip install torch torchaudio
 ```
 
 ### Model download
 ```bash
-huggingface-cli download FunAudioLLM/CosyVoice2-0.5B
+huggingface-cli download FunAudioLLM/CosyVoice2-0.5B --local-dir backends/extras/cosyvoice2/CosyVoice2-0.5B
 ```
 Disk: 2.0 GB
 
 ### Python API for cloning
 ```python
-from cosyvoice.cli.cosyvoice import CosyVoice
-from cosyvoice.utils.file_utils import load_wav
+from cosyvoice.cli.cosyvoice import CosyVoice2
 import torchaudio
 
-cosyvoice = CosyVoice('pretrained_models/CosyVoice2-0.5B')
-prompt_speech_16k = load_wav('reference.wav', 16000)
-output = cosyvoice.inference_zero_shot(
-    'This is a test sentence.', 
-    prompt_text='This is the text spoken in the reference audio.', 
-    prompt_speech_16k=prompt_speech_16k
-)
-torchaudio.save('output.wav', output['tts_speech'], 22050)
+cosyvoice = CosyVoice2('pretrained_models/CosyVoice2-0.5B')
+for i, output in enumerate(cosyvoice.inference_zero_shot(
+    'This is a test sentence.',
+    'This is the text spoken in the reference audio.',
+    'reference.wav',
+    stream=False,
+)):
+    torchaudio.save(f'output_{i}.wav', output['tts_speech'], cosyvoice.sample_rate)
 ```
 
 ### Backend protocol skeleton
@@ -44,9 +42,9 @@ from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class CosyVoice2Backend(BackendBase):
     name = "cosyvoice2"
-    sample_rate = 22050
+    sample_rate = 24000
     ref_text_policy = RefTextPolicy.REQUIRED
-    supported_langs = ("multilingual",)
+    supported_langs = ("en", "zh", "ja", "ko", "de", "es", "fr", "it", "ru")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
@@ -54,6 +52,8 @@ class CosyVoice2Backend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- CosyVoice2 strictly requires the `prompt_text` (transcript of the reference audio) to align semantic tokens perfectly during the zero-shot cloning phase. In `prepare_voice`, you will need to enforce the presence of `ref_text`. A known quirk on Macs is managing the 16kHz resampling for the prompt audio vs the 22.05kHz generated output—make sure your backend seamlessly resamples user-provided `ref_audio_path` using `torchaudio.transforms.Resample` before sending it into the model.
+- CosyVoice2 strictly requires the `prompt_text` (transcript of the reference audio) to align semantic tokens during the zero-shot cloning phase. In `prepare_voice`, enforce the presence of `ref_text`.
+- Current upstream `CosyVoice2.inference_zero_shot` takes `(tts_text, prompt_text, prompt_wav, zero_shot_spk_id='', stream=False, speed=1.0, text_frontend=True)`. The frontend calls `load_wav(prompt_wav, 16000)` for speech token extraction and `load_wav(prompt_wav, 24000)` for speech features internally, so Afterwords can pass the reference WAV path directly rather than preloading a `prompt_speech_16k` tensor.
+- Do not auto-download weights from the backend during normal server startup. Require a local model directory (default `backends/extras/cosyvoice2/CosyVoice2-0.5B`) or `COSYVOICE2_MODEL_DIR`.
 
 ---

--- a/requirements-cosyvoice2.txt
+++ b/requirements-cosyvoice2.txt
@@ -1,0 +1,32 @@
+# Optional CosyVoice2-0.5B backend dependencies.
+#
+# Install these only if you plan to use backend=cosyvoice2 voice profiles:
+#   pip install -r requirements-cosyvoice2.txt
+#
+# Download weights separately; the backend does not auto-download them:
+#   huggingface-cli download FunAudioLLM/CosyVoice2-0.5B \
+#     --local-dir backends/extras/cosyvoice2/CosyVoice2-0.5B
+#
+# CosyVoice upstream code and CosyVoice2-0.5B weights are Apache-2.0.
+git+https://github.com/FunAudioLLM/CosyVoice.git
+torch==2.3.1
+torchaudio==2.3.1
+onnxruntime==1.18.0; sys_platform == 'darwin' or sys_platform == 'win32'
+onnxruntime-gpu==1.18.0; sys_platform == 'linux'
+openai-whisper==20231117
+conformer==0.3.2
+diffusers==0.29.0
+gdown==5.1.0
+hydra-core==1.3.2
+HyperPyYAML==1.2.3
+inflect==7.3.1
+librosa==0.10.2
+modelscope==1.20.0
+numpy==1.26.4
+omegaconf==2.3.0
+protobuf==4.25
+pyworld==0.3.4
+soundfile==0.12.1
+transformers==4.51.3
+wetext==0.0.4
+x-transformers==2.11.24

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,7 +18,7 @@ def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
-        "openvoice-v2", "f5-tts",
+        "openvoice-v2", "f5-tts", "cosyvoice2",
     }
 
 
@@ -561,3 +561,95 @@ def test_f5_tts_synthesize_uses_f5_api_and_generation_extras():
     assert captured_kwargs["speed"] == 1.1
     assert captured_kwargs["seed"] == 123
     assert captured_kwargs["progress"] is None
+
+
+def test_cosyvoice2_metadata():
+    from backends.cosyvoice2 import CosyVoice2Backend
+
+    backend = CosyVoice2Backend()
+
+    assert backend.name == "cosyvoice2"
+    assert backend.display_name == "CosyVoice2-0.5B (Apache-2.0)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.REQUIRED
+    assert backend.supported_langs == ("en", "zh", "ja", "ko", "de", "es", "fr", "it", "ru")
+
+
+def test_cosyvoice2_prepare_voice_requires_ref_text():
+    from backends.cosyvoice2 import CosyVoice2Backend
+
+    backend = CosyVoice2Backend()
+
+    with pytest.raises(ValueError, match="requires reference_text"):
+        backend.prepare_voice("/tmp/ref.wav", "  ", {})
+
+
+def test_cosyvoice2_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.cosyvoice2 import CosyVoice2Backend
+
+    backend = CosyVoice2Backend()
+
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"emotion": "happy"})
+    with pytest.raises(ValueError, match="speed must be > 0"):
+        backend.validate_extras({"speed": 0})
+    with pytest.raises(ValueError, match="text_frontend must be boolean"):
+        backend.validate_extras({"text_frontend": "yes"})
+
+
+def test_cosyvoice2_synthesize_raises_before_load():
+    from backends.cosyvoice2 import CosyVoice2Backend
+
+    backend = CosyVoice2Backend()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="called before load"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_cosyvoice2_synthesize_uses_zero_shot_api_and_concatenates_chunks():
+    import numpy as np
+    from backends.cosyvoice2 import CosyVoice2Backend
+
+    backend = CosyVoice2Backend()
+    captured = {}
+
+    class _Tensorish:
+        def __init__(self, values):
+            self.values = np.asarray(values, dtype=np.float32)
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self.values
+
+    class _CosyModel:
+        sample_rate = 24000
+
+        def inference_zero_shot(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            yield {"tts_speech": _Tensorish([[0.1, 0.2]])}
+            yield {"tts_speech": _Tensorish([[-0.1]])}
+
+    backend._model = _CosyModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({"speed": 1.2, "text_frontend": False}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert np.allclose(audio, [0.1, 0.2, -0.1])
+    assert captured["args"] == ("hello", "reference text", "/tmp/ref.wav")
+    assert captured["kwargs"] == {"stream": False, "speed": 1.2, "text_frontend": False}


### PR DESCRIPTION
## Summary

Adds an optional `cosyvoice2` backend for FunAudioLLM CosyVoice2-0.5B.

- Implements `CosyVoice2Backend` with lazy imports, required reference text, multilingual language metadata, optional `speed` and `text_frontend` extras, and chunk concatenation for upstream zero-shot output.
- Registers the backend after F5-TTS and documents Apache-2.0 licensing plus optional install requirements.
- Updates the CosyVoice2 research note after verifying current upstream API: `CosyVoice2.inference_zero_shot(tts_text, prompt_text, prompt_wav, ...)`.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`
- `.venv/bin/python -m py_compile backends/cosyvoice2.py`
- `git diff --check`

No model weights were downloaded.