### PR TITLE
feat: add GPT-SoVITS backend (open-source few-shot cloning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, and CosyVoice2.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, and GPT-SoVITS.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -231,6 +231,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `openvoice-v2` | MIT | en/es/fr/zh/ja/ko | 22.05 kHz | optional |
 | `f5-tts` | CC-BY-NC default weights | en/zh | 24 kHz | required |
 | `cosyvoice2` | Apache-2.0 | en/zh/ja/ko/de/es/fr/it/ru | 24 kHz | required |
+| `gpt-sovits` | MIT | en/zh/ja/ko/yue | 32 kHz | required |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -35,6 +35,7 @@ def register_all() -> None:
     from .openvoice_v2 import OpenVoiceV2Backend
     from .f5_tts import F5TTSBackend
     from .cosyvoice2 import CosyVoice2Backend
+    from .gpt_sovits import GPTSoVITSBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -44,6 +45,7 @@ def register_all() -> None:
     register(OpenVoiceV2Backend())
     register(F5TTSBackend())
     register(CosyVoice2Backend())
+    register(GPTSoVITSBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/gpt_sovits.py
+++ b/backends/gpt_sovits.py
@@ -1,0 +1,238 @@
+"""GPT-SoVITS backend via RVC-Boss GPT-SoVITS.
+
+GPT-SoVITS upstream code is MIT licensed. The default public weights from
+lj1995/GPT-SoVITS are published for the upstream project; verify any
+third-party fine-tuned weights before commercial use.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from collections.abc import Iterator
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.gpt_sovits")
+
+MODEL_ID = "lj1995/GPT-SoVITS"
+NATIVE_SR = 32000
+SUPPORTED_LANGS = ("en", "zh", "ja", "ko", "yue")
+DEFAULT_REPO_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "gpt-sovits",
+    "GPT-SoVITS",
+)
+
+_ALLOWED_EXTRAS = {
+    "prompt_lang",
+    "prompt_language",
+    "text_language",
+    "how_to_cut",
+    "top_k",
+    "top_p",
+    "temperature",
+    "speed",
+    "sample_steps",
+    "pause_second",
+}
+
+_INT_EXTRAS = {"top_k", "sample_steps"}
+_FLOAT_EXTRAS = {"top_p", "temperature", "speed", "pause_second"}
+
+
+def _get_tts_wav_import():
+    try:
+        from GPT_SoVITS.inference import get_tts_wav
+
+        return get_tts_wav
+    except ImportError:
+        from GPT_SoVITS.inference_webui import get_tts_wav
+
+        return get_tts_wav
+
+
+def _repo_dir() -> str:
+    return os.environ.get("GPT_SOVITS_REPO_DIR", DEFAULT_REPO_DIR)
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if isinstance(audio, tuple) and len(audio) == 2:
+        audio = audio[1]
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _coerce_chunk(chunk) -> tuple[np.ndarray, int | None]:
+    if isinstance(chunk, tuple) and len(chunk) == 2 and isinstance(chunk[0], (int, np.integer)):
+        return _to_numpy(chunk[1]), int(chunk[0])
+    if isinstance(chunk, Mapping):
+        audio = chunk.get("audio", chunk.get("wav", chunk.get("tts_speech")))
+        if audio is None:
+            raise RuntimeError("GPT-SoVITS produced an invalid output chunk")
+        sr = chunk.get("sample_rate", chunk.get("sr"))
+        return _to_numpy(audio), int(sr) if sr is not None else None
+    return _to_numpy(chunk), None
+
+
+class GPTSoVITSBackend(BackendBase):
+    name = "gpt-sovits"
+    display_name = "GPT-SoVITS (MIT)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.REQUIRED
+    supported_langs = SUPPORTED_LANGS
+
+    def __init__(self):
+        super().__init__()
+        self._get_tts_wav = None
+        self._repo_dir = _repo_dir()
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            repo_dir = _repo_dir()
+            if os.path.isdir(repo_dir) and repo_dir not in sys.path:
+                sys.path.insert(0, repo_dir)
+            try:
+                self._get_tts_wav = _get_tts_wav_import()
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-gpt-sovits.txt, clone GPT-SoVITS to "
+                    f"{repo_dir!r} or set GPT_SOVITS_REPO_DIR, and configure weights"
+                )
+                log.warning("GPT-SoVITS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            self._repo_dir = repo_dir
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"GPT-SoVITS does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in ("prompt_lang", "prompt_language", "text_language", "how_to_cut"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"GPT-SoVITS {key} must be a string; got {value!r}")
+        for key in ("prompt_lang", "prompt_language", "text_language"):
+            value = extras.get(key)
+            if value is not None and value not in self.supported_langs:
+                raise ValueError(
+                    f"GPT-SoVITS {key} must be one of {self.supported_langs}; got {value!r}"
+                )
+        for key in _INT_EXTRAS:
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"GPT-SoVITS {key} must be an integer; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"GPT-SoVITS {key} must be > 0; got {value!r}")
+        for key in _FLOAT_EXTRAS:
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"GPT-SoVITS {key} must be numeric; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"GPT-SoVITS {key} must be > 0; got {value!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if not ref_text or not ref_text.strip():
+            raise ValueError("GPT-SoVITS requires reference_text aligned with reference audio")
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text.strip(),
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._get_tts_wav is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"GPT-SoVITS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("GPTSoVITSBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"gpt-sovits does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+        if not prepared.ref_text:
+            raise RuntimeError("GPT-SoVITS prepared voice is missing reference_text")
+
+        prompt_language = str(
+            prepared.extras.get("prompt_language", prepared.extras.get("prompt_lang", lang))
+        )
+        text_language = str(prepared.extras.get("text_language", lang))
+        if prompt_language not in self.supported_langs:
+            raise ValueError(
+                "GPT-SoVITS prompt_language must be one of "
+                f"{self.supported_langs}; got {prompt_language!r}"
+            )
+        if text_language not in self.supported_langs:
+            raise ValueError(
+                "GPT-SoVITS text_language must be one of "
+                f"{self.supported_langs}; got {text_language!r}"
+            )
+
+        kwargs = {
+            "ref_wav_path": prepared.ref_audio_path,
+            "prompt_text": prepared.ref_text,
+            "prompt_language": prompt_language,
+            "text": text,
+            "text_language": text_language,
+        }
+        for key in (
+            "how_to_cut",
+            "top_k",
+            "top_p",
+            "temperature",
+            "speed",
+            "sample_steps",
+            "pause_second",
+        ):
+            if key in prepared.extras:
+                kwargs[key] = prepared.extras[key]
+
+        output = self._get_tts_wav(**kwargs)
+        if isinstance(output, Iterator):
+            chunks = output
+        elif isinstance(output, list):
+            chunks = output
+        else:
+            chunks = (output,)
+        audio_chunks = []
+        sample_rate = None
+        for chunk in chunks:
+            audio, chunk_sr = _coerce_chunk(chunk)
+            if audio.size:
+                audio_chunks.append(audio)
+            if chunk_sr is not None:
+                sample_rate = chunk_sr
+
+        if not audio_chunks:
+            raise RuntimeError("GPT-SoVITS produced no output")
+        audio = audio_chunks[0] if len(audio_chunks) == 1 else np.concatenate(audio_chunks)
+        return audio.astype(np.float32, copy=False), int(sample_rate or self.sample_rate)

--- a/docs/research/tts-backends/gpt-sovits.md
+++ b/docs/research/tts-backends/gpt-sovits.md
@@ -4,8 +4,8 @@
 **License:** MIT
 **Size:** 2.0 GB
 **Sample rate:** 32000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: Native support via macOS environments; the community has created specialized single-click installers, but the programmatic API runs cleanly on M5.
+**Languages:** en, zh, ja, ko, yue
+**Apple Silicon path:** PyTorch+MPS or CPU via upstream `install.sh --device <MPS|CPU>`; upstream currently lists tested Apple Silicon environments for Python 3.9/PyTorch 2.5.1 and Python 3.11/PyTorch 2.7.0.
 
 ### Install
 ```bash
@@ -22,7 +22,9 @@ Disk: 2.0 GB
 
 ### Python API for cloning
 ```python
-from GPT_SoVITS.inference import get_tts_wav
+# Current upstream exposes this from inference_webui.py; some packaged
+# integrations may wrap it as GPT_SoVITS.inference.get_tts_wav.
+from GPT_SoVITS.inference_webui import get_tts_wav
 
 # API wrapper assumes configurations are pointed to weights correctly
 audio_generator = get_tts_wav(
@@ -41,10 +43,10 @@ audio_data = next(audio_generator)
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class GPTSoVITSBackend(BackendBase):
-    name = "gpt_sovits"
+    name = "gpt-sovits"
     sample_rate = 32000
     ref_text_policy = RefTextPolicy.REQUIRED
-    supported_langs = ("multilingual",)
+    supported_langs = ("en", "zh", "ja", "ko", "yue")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...

--- a/requirements-gpt-sovits.txt
+++ b/requirements-gpt-sovits.txt
@@ -1,0 +1,17 @@
+# Optional GPT-SoVITS backend dependencies.
+#
+# Install these only if you plan to use backend=gpt-sovits voice profiles:
+#   pip install -r requirements-gpt-sovits.txt
+#
+# Clone the GPT-SoVITS source separately; the backend adds this default path
+# to PYTHONPATH when it exists, or set GPT_SOVITS_REPO_DIR:
+#   git clone https://github.com/RVC-Boss/GPT-SoVITS.git \
+#     backends/extras/gpt-sovits/GPT-SoVITS
+#
+# Download and configure weights separately; this requirements file and backend
+# do not auto-download them:
+#   huggingface-cli download lj1995/GPT-SoVITS
+#
+# GPT-SoVITS upstream code is MIT licensed. Check the license of any
+# third-party fine-tuned weights you configure.
+-r https://raw.githubusercontent.com/RVC-Boss/GPT-SoVITS/main/requirements.txt

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,7 +18,7 @@ def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
-        "openvoice-v2", "f5-tts", "cosyvoice2",
+        "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits",
     }
 
 
@@ -318,6 +318,102 @@ def test_voxtral_synthesize_uses_voice_extra_and_concatenates_chunks():
     assert audio.shape == (10,)
     assert np.allclose(audio[:4], 0.1)
     assert np.allclose(audio[4:], 0.2)
+
+
+def test_gpt_sovits_requires_reference_text():
+    from backends.gpt_sovits import GPTSoVITSBackend
+
+    backend = GPTSoVITSBackend()
+    with pytest.raises(ValueError, match="requires reference_text"):
+        backend.prepare_voice("/tmp/ref.wav", "  ", {})
+
+
+def test_gpt_sovits_validate_extras_rejects_unknown_and_invalid_lang():
+    from backends.gpt_sovits import GPTSoVITSBackend
+
+    backend = GPTSoVITSBackend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"cfg_value": 2.0})
+    with pytest.raises(ValueError, match="prompt_language must be one of"):
+        backend.validate_extras({"prompt_language": "de"})
+
+
+def test_gpt_sovits_synthesize_calls_upstream_api_and_concatenates_chunks():
+    import numpy as np
+    from backends.gpt_sovits import GPTSoVITSBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = GPTSoVITSBackend()
+    captured_kwargs = {}
+
+    def _fake_get_tts_wav(**kwargs):
+        captured_kwargs.update(kwargs)
+        yield 32000, np.full(4, 0.1, dtype=np.float32)
+        yield 32000, np.full(6, 0.2, dtype=np.float32)
+
+    backend._get_tts_wav = _fake_get_tts_wav
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference transcript",
+        extras=_read_only({"prompt_language": "en", "top_k": 15, "speed": 1.1}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="zh")
+
+    assert sr == 32000
+    assert captured_kwargs == {
+        "ref_wav_path": "/tmp/ref.wav",
+        "prompt_text": "reference transcript",
+        "prompt_language": "en",
+        "text": "hello",
+        "text_language": "zh",
+        "top_k": 15,
+        "speed": 1.1,
+    }
+    assert audio.shape == (10,)
+    assert np.allclose(audio[:4], 0.1)
+    assert np.allclose(audio[4:], 0.2)
+
+
+def test_gpt_sovits_synthesize_accepts_mapping_chunks():
+    import numpy as np
+    from backends.gpt_sovits import GPTSoVITSBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = GPTSoVITSBackend()
+
+    def _fake_get_tts_wav(**kwargs):
+        yield {"audio": np.full(3, 0.25, dtype=np.float32), "sample_rate": 48000}
+
+    backend._get_tts_wav = _fake_get_tts_wav
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference transcript",
+        extras=_read_only({}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 48000
+    assert audio.dtype == np.float32
+    assert audio.shape == (3,)
+    assert np.allclose(audio, 0.25)
+
+
+def test_gpt_sovits_synthesize_raises_on_empty_generator():
+    from backends.gpt_sovits import GPTSoVITSBackend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = GPTSoVITSBackend()
+    backend._get_tts_wav = lambda **kwargs: (x for x in ())
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference transcript",
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
 
 
 def test_voxtral_synthesize_raises_on_empty_generator():


### PR DESCRIPTION
## Summary
- add optional GPT-SoVITS backend with lazy imports and generator output normalization
- register gpt-sovits after CosyVoice2 and document optional install/runtime details
- add mocked backend tests for metadata, validation, upstream API calls, chunk handling, and empty output

## Verification
- PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v
- PYTHONPATH=. .venv/bin/python -m py_compile backends/gpt_sovits.py