### PR TITLE
feat: add XTTS v2 backend (Coqui multilingual, CPML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, and GPT-SoVITS.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, and XTTS v2.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -232,6 +232,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `f5-tts` | CC-BY-NC default weights | en/zh | 24 kHz | required |
 | `cosyvoice2` | Apache-2.0 | en/zh/ja/ko/de/es/fr/it/ru | 24 kHz | required |
 | `gpt-sovits` | MIT | en/zh/ja/ko/yue | 32 kHz | required |
+| `xtts-v2` | CPML, non-commercial only | en/es/fr/de/it/pt/pl/tr/ru/nl/cs/ar/zh/hu/ko/ja/hi | 24 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -438,6 +439,7 @@ On 32 GB M3 Max (four backends preloaded):
 - [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS) by Alibaba (Apache 2.0)
 - [mlx-audio](https://github.com/Blaizzy/mlx-audio) by Blaizzy
 - [OpenVoice](https://github.com/myshell-ai/OpenVoice) and [MeloTTS](https://github.com/myshell-ai/MeloTTS) by MyShell (MIT)
+- [Coqui TTS / XTTS v2](https://github.com/coqui-ai/TTS) by Coqui (code MPL-2.0; XTTS v2 weights CPML, non-commercial only)
 - [MLX](https://github.com/ml-explore/mlx) by Apple
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/) by Anthropic
 - Voice reference clips used under fair use for personal voice synthesis research

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -36,6 +36,7 @@ def register_all() -> None:
     from .f5_tts import F5TTSBackend
     from .cosyvoice2 import CosyVoice2Backend
     from .gpt_sovits import GPTSoVITSBackend
+    from .xtts_v2 import XTTSv2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -46,6 +47,7 @@ def register_all() -> None:
     register(F5TTSBackend())
     register(CosyVoice2Backend())
     register(GPTSoVITSBackend())
+    register(XTTSv2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/xtts_v2.py
+++ b/backends/xtts_v2.py
@@ -1,0 +1,142 @@
+"""XTTS v2 backend via Coqui TTS.
+
+Coqui TTS code is MPL-2.0, but the XTTS v2 model weights are licensed under
+the Coqui Public Model License (CPML). CPML restricts use to non-commercial
+purposes; do not use this backend for commercial work unless you have separate
+rights to compatible weights.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.xtts_v2")
+
+MODEL_ID = "tts_models/multilingual/multi-dataset/xtts_v2"
+NATIVE_SR = 24000
+SUPPORTED_LANGS = (
+    "en",
+    "es",
+    "fr",
+    "de",
+    "it",
+    "pt",
+    "pl",
+    "tr",
+    "ru",
+    "nl",
+    "cs",
+    "ar",
+    "zh",
+    "hu",
+    "ko",
+    "ja",
+    "hi",
+)
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("XTTS_V2_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+class XTTSv2Backend(BackendBase):
+    name = "xtts-v2"
+    display_name = "XTTS v2 (CPML, non-commercial)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = SUPPORTED_LANGS
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from TTS.api import TTS
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-xtts.txt"
+                )
+                log.warning("XTTS v2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            device = _device(torch)
+            model_id = os.environ.get("XTTS_V2_MODEL", MODEL_ID)
+            log.info("loading %s on %s ...", model_id, device)
+            self._model = TTS(model_id, progress_bar=False).to(device)
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - set()
+        if unknown:
+            raise ValueError(f"XTTS v2 does not accept extras: {sorted(unknown)}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"XTTS v2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("XTTSv2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"xtts-v2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        audio = self._model.tts(
+            text=text,
+            speaker_wav=prepared.ref_audio_path,
+            language=lang,
+        )
+        if audio is None:
+            raise RuntimeError("XTTS v2 produced no output")
+        return _to_numpy(audio), self.sample_rate

--- a/requirements-xtts.txt
+++ b/requirements-xtts.txt
@@ -1,0 +1,11 @@
+# Optional XTTS v2 backend dependencies.
+#
+# Install these only if you plan to use backend=xtts-v2 voice profiles:
+#   pip install -r requirements-xtts.txt
+#
+# XTTS v2 weights are licensed under the Coqui Public Model License (CPML),
+# which restricts use to non-commercial purposes.
+# Coqui TTS v0.22+ supports Python 3.11+ and the XTTS v2 API used here.
+TTS>=0.22
+torch>=2.1
+torchaudio>=2.1

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,7 +18,7 @@ def test_register_all_populates_shipped_backends():
     backends.register_all()
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
-        "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits",
+        "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
     }
 
 
@@ -749,3 +749,101 @@ def test_cosyvoice2_synthesize_uses_zero_shot_api_and_concatenates_chunks():
     assert np.allclose(audio, [0.1, 0.2, -0.1])
     assert captured["args"] == ("hello", "reference text", "/tmp/ref.wav")
     assert captured["kwargs"] == {"stream": False, "speed": 1.2, "text_frontend": False}
+
+
+def test_xtts_v2_metadata():
+    from backends.xtts_v2 import XTTSv2Backend
+
+    backend = XTTSv2Backend()
+
+    assert backend.name == "xtts-v2"
+    assert backend.display_name == "XTTS v2 (CPML, non-commercial)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == (
+        "en", "es", "fr", "de", "it", "pt", "pl", "tr", "ru",
+        "nl", "cs", "ar", "zh", "hu", "ko", "ja", "hi",
+    )
+
+
+def test_xtts_v2_prepare_voice_allows_missing_ref_text_and_rejects_extras():
+    from backends.xtts_v2 import XTTSv2Backend
+
+    backend = XTTSv2Backend()
+
+    prepared = backend.prepare_voice("/tmp/ref.wav", "  ", {})
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text is None
+
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.prepare_voice("/tmp/ref.wav", None, {"speed": 1.1})
+
+
+def test_xtts_v2_synthesize_raises_before_load():
+    from backends.xtts_v2 import XTTSv2Backend
+
+    backend = XTTSv2Backend()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="called before load"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_xtts_v2_synthesize_rejects_unsupported_language():
+    from backends.xtts_v2 import XTTSv2Backend
+
+    backend = XTTSv2Backend()
+    backend._model = object()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='yue'"):
+        backend.synthesize("nei hou", prepared, lang="yue")
+
+
+def test_xtts_v2_synthesize_uses_coqui_api_and_returns_float32_audio():
+    import numpy as np
+    from backends.xtts_v2 import XTTSv2Backend
+
+    backend = XTTSv2Backend()
+    captured_kwargs = {}
+
+    class _Tensorish:
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return np.array([[0.2, -0.4]], dtype=np.float64)
+
+    class _XTTSModel:
+        def tts(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return _Tensorish()
+
+    backend._model = _XTTSModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.2, -0.4])
+    assert captured_kwargs == {
+        "text": "hello",
+        "speaker_wav": "/tmp/ref.wav",
+        "language": "en",
+    }


### PR DESCRIPTION
## Summary

Adds an optional Coqui XTTS v2 backend for multilingual zero-shot voice cloning.

- Implements `backends/xtts_v2.py` with lazy Coqui/PyTorch imports, MPS fallback support, optional reference text, and the upstream `tts.tts(text, speaker_wav=..., language=...)` API.
- Registers `xtts-v2` after GPT-SoVITS in `register_all()`.
- Adds mocked backend tests covering metadata, optional reference text, unsupported languages, before-load errors, and Coqui API dispatch.
- Adds `requirements-xtts.txt` for optional dependencies.
- Documents XTTS v2 in the README with prominent CPML/non-commercial-only licensing notes.

## Licensing

XTTS v2 model weights are licensed under the Coqui Public Model License (CPML), which restricts use to non-commercial purposes. The backend module docstring, optional requirements file, and README all call this out.

## Validation

`PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`

Result: 45 passed.