### PR TITLE
feat: add IndexTTS-2 backend (emotion + duration control)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, and XTTS v2.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, and IndexTTS-2.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -233,6 +233,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `cosyvoice2` | Apache-2.0 | en/zh/ja/ko/de/es/fr/it/ru | 24 kHz | required |
 | `gpt-sovits` | MIT | en/zh/ja/ko/yue | 32 kHz | required |
 | `xtts-v2` | CPML, non-commercial only | en/es/fr/de/it/pt/pl/tr/ru/nl/cs/ar/zh/hu/ko/ja/hi | 24 kHz | optional |
+| `indextts-2` | LicenseRef-Bilibili-IndexTTS | en/zh | 22.05 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -37,6 +37,7 @@ def register_all() -> None:
     from .cosyvoice2 import CosyVoice2Backend
     from .gpt_sovits import GPTSoVITSBackend
     from .xtts_v2 import XTTSv2Backend
+    from .indextts_2 import IndexTTS2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -48,6 +49,7 @@ def register_all() -> None:
     register(CosyVoice2Backend())
     register(GPTSoVITSBackend())
     register(XTTSv2Backend())
+    register(IndexTTS2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/indextts_2.py
+++ b/backends/indextts_2.py
@@ -1,0 +1,277 @@
+"""IndexTTS-2 backend via index-tts.
+
+IndexTTS-2 uses the bilibili Model Use License
+(`LicenseRef-Bilibili-IndexTTS`), which includes usage restrictions. Review
+the upstream license before production or commercial use.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Sequence
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.indextts_2")
+
+MODEL_ID = "IndexTeam/IndexTTS-2"
+NATIVE_SR = 22050
+DEFAULT_MODEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "indextts-2",
+    "checkpoints",
+)
+
+_ALLOWED_EXTRAS = {
+    "emo_alpha",
+    "emo_audio_prompt",
+    "emo_text",
+    "emo_vector",
+    "interval_silence",
+    "length_penalty",
+    "max_mel_tokens",
+    "max_text_tokens_per_segment",
+    "num_beams",
+    "repetition_penalty",
+    "temperature",
+    "top_k",
+    "top_p",
+    "use_emo_text",
+    "use_random",
+}
+_FLOAT_EXTRAS = {
+    "emo_alpha",
+    "interval_silence",
+    "length_penalty",
+    "repetition_penalty",
+    "temperature",
+    "top_p",
+}
+_INT_EXTRAS = {"max_mel_tokens", "max_text_tokens_per_segment", "num_beams", "top_k"}
+_EMOTION_VECTOR_LEN = 8
+
+
+def _model_dir() -> str:
+    return os.environ.get("INDEXTTS2_MODEL_DIR", DEFAULT_MODEL_DIR)
+
+
+def _cfg_path(model_dir: str) -> str:
+    return os.environ.get("INDEXTTS2_CFG_PATH", os.path.join(model_dir, "config.yaml"))
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("INDEXTTS2_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda:0"
+    if getattr(torch, "xpu", None) is not None and torch.xpu.is_available():
+        return "xpu"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    audio = np.asarray(audio)
+    if np.issubdtype(audio.dtype, np.integer):
+        max_value = float(np.iinfo(audio.dtype).max)
+        audio = audio.astype(np.float32) / max_value
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _coerce_infer_output(output) -> tuple[np.ndarray, int]:
+    if output is None:
+        raise RuntimeError("IndexTTS-2 produced no output")
+    if isinstance(output, tuple) and len(output) == 2:
+        sr, audio = output
+        return _to_numpy(audio), int(sr)
+    if isinstance(output, Mapping):
+        audio = output.get("audio", output.get("wav", output.get("tts_speech")))
+        if audio is None:
+            raise RuntimeError("IndexTTS-2 produced an invalid output")
+        sr = output.get("sample_rate", output.get("sr", NATIVE_SR))
+        return _to_numpy(audio), int(sr)
+    return _to_numpy(output), NATIVE_SR
+
+
+class IndexTTS2Backend(BackendBase):
+    name = "indextts-2"
+    display_name = "IndexTTS-2 (bilibili Model Use License)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en", "zh")
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._model_dir = _model_dir()
+        self._cfg_path = _cfg_path(self._model_dir)
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from indextts.infer_v2 import IndexTTS2
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-indextts.txt"
+                )
+                log.warning("IndexTTS-2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            model_dir = _model_dir()
+            cfg_path = _cfg_path(model_dir)
+            if not os.path.exists(cfg_path):
+                self._unavailable_reason = (
+                    "IndexTTS-2 checkpoints not found. Download "
+                    f"{MODEL_ID} to {model_dir!r} or set INDEXTTS2_MODEL_DIR."
+                )
+                log.warning("IndexTTS-2 unavailable: %s", self._unavailable_reason)
+                return
+
+            device = _device(torch)
+            log.info("loading %s from %s on %s ...", MODEL_ID, model_dir, device)
+            self._model = IndexTTS2(
+                cfg_path=cfg_path,
+                model_dir=model_dir,
+                device=device,
+                use_fp16=_env_bool("INDEXTTS2_FP16", False),
+                use_cuda_kernel=_env_bool("INDEXTTS2_CUDA_KERNEL", False),
+                use_deepspeed=_env_bool("INDEXTTS2_DEEPSPEED", False),
+                use_accel=_env_bool("INDEXTTS2_ACCEL", False),
+                use_torch_compile=_env_bool("INDEXTTS2_TORCH_COMPILE", False),
+            )
+            self._model_dir = model_dir
+            self._cfg_path = cfg_path
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"IndexTTS-2 does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in _FLOAT_EXTRAS:
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"IndexTTS-2 {key} must be numeric; got {value!r}")
+        for key in _INT_EXTRAS:
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"IndexTTS-2 {key} must be an integer; got {value!r}")
+        for key in ("emo_audio_prompt", "emo_text"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"IndexTTS-2 {key} must be a string; got {value!r}")
+        for key in ("use_emo_text", "use_random"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, bool):
+                raise ValueError(f"IndexTTS-2 {key} must be boolean; got {value!r}")
+
+        if extras.get("emo_alpha") is not None and not 0 <= extras["emo_alpha"] <= 1:
+            raise ValueError(f"IndexTTS-2 emo_alpha must be between 0 and 1; got {extras['emo_alpha']!r}")
+        for key in ("interval_silence",):
+            if extras.get(key) is not None and extras[key] < 0:
+                raise ValueError(f"IndexTTS-2 {key} must be >= 0; got {extras[key]!r}")
+        for key in ("temperature", "top_p"):
+            if extras.get(key) is not None and extras[key] <= 0:
+                raise ValueError(f"IndexTTS-2 {key} must be > 0; got {extras[key]!r}")
+        for key in ("max_mel_tokens", "max_text_tokens_per_segment", "num_beams", "top_k"):
+            if extras.get(key) is not None and extras[key] <= 0:
+                raise ValueError(f"IndexTTS-2 {key} must be > 0; got {extras[key]!r}")
+
+        emo_vector = extras.get("emo_vector")
+        if emo_vector is not None:
+            if (
+                isinstance(emo_vector, (str, bytes))
+                or not isinstance(emo_vector, Sequence)
+                or len(emo_vector) != _EMOTION_VECTOR_LEN
+            ):
+                raise ValueError(
+                    "IndexTTS-2 emo_vector must be a sequence of "
+                    f"{_EMOTION_VECTOR_LEN} numeric values"
+                )
+            for value in emo_vector:
+                if not isinstance(value, (int, float)):
+                    raise ValueError(
+                        "IndexTTS-2 emo_vector must contain numeric values; "
+                        f"got {value!r}"
+                    )
+                if value < 0:
+                    raise ValueError(
+                        "IndexTTS-2 emo_vector values must be >= 0; "
+                        f"got {value!r}"
+                    )
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"IndexTTS-2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("IndexTTS2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"indextts-2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        kwargs = {
+            "spk_audio_prompt": prepared.ref_audio_path,
+            "text": text,
+            "output_path": None,
+            "verbose": False,
+        }
+        for key in _ALLOWED_EXTRAS:
+            if key in prepared.extras:
+                kwargs[key] = prepared.extras[key]
+
+        output = self._model.infer(**kwargs)
+        audio, sample_rate = _coerce_infer_output(output)
+        if not audio.size:
+            raise RuntimeError("IndexTTS-2 produced no output")
+        return audio.astype(np.float32, copy=False), sample_rate

--- a/docs/research/tts-backends/indextts-2.md
+++ b/docs/research/tts-backends/indextts-2.md
@@ -1,47 +1,54 @@
 ## IndexTTS-2
 
-**Repo:** https://huggingface.co/IndexTeam/IndexTTS-2
-**License:** Open Source
-**Size:** 1.5B, 3.0 GB
-**Sample rate:** 24000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: High RAM footprint, but comfortably fits inside the 32GB unified memory of the M5.
+**Repo:** https://github.com/index-tts/index-tts
+**Weights:** https://huggingface.co/IndexTeam/IndexTTS-2
+**License:** `LicenseRef-Bilibili-IndexTTS` (bilibili Model Use License; usage restrictions)
+**Size:** 1.5B, ~3.0 GB
+**Sample rate:** 22050
+**Languages:** en/zh in the current upstream package
+**Apple Silicon path:** PyTorch+MPS — upstream supports MPS device selection, but disables fp16 on MPS.
 
 ### Install
 ```bash
-git clone https://github.com/IndexTeam/IndexTTS.git
-cd IndexTTS
-pip install -r requirements.txt torch torchaudio
+git clone https://github.com/index-tts/index-tts.git
+cd index-tts
+uv sync --all-extras
 ```
 
 ### Model download
 ```bash
-huggingface-cli download IndexTeam/IndexTTS-2
+huggingface-cli download IndexTeam/IndexTTS-2 --local-dir checkpoints
 ```
 Disk: 3.0 GB
 
 ### Python API for cloning
 ```python
-from indextts import IndexTTS
+from indextts.infer_v2 import IndexTTS2
 
-model = IndexTTS.from_pretrained("IndexTeam/IndexTTS-2").to("mps")
-audio = model.synthesize(
+tts = IndexTTS2(
+    cfg_path="checkpoints/config.yaml",
+    model_dir="checkpoints",
+    use_fp16=False,
+    use_cuda_kernel=False,
+    use_deepspeed=False,
+)
+audio = tts.infer(
+    spk_audio_prompt="reference.wav",
     text="This is a test sentence.",
-    ref_audio="reference.wav",
-    ref_text="Reference transcript."
+    output_path=None,
 )
 ```
 
 ### Backend protocol skeleton
 ```python
-# backends/indextts2.py
+# backends/indextts_2.py
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class IndexTTS2Backend(BackendBase):
-    name = "indextts_2"
-    sample_rate = 24000
-    ref_text_policy = RefTextPolicy.REQUIRED
-    supported_langs = ("multilingual",)
+    name = "indextts-2"
+    sample_rate = 22050
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en", "zh")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
@@ -49,6 +56,8 @@ class IndexTTS2Backend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- IndexTTS-2 specializes in explicit token specification for precise duration and emotional control. Because it is highly capable of separating emotional expression from speaker identity, you might want to expose optional parameters via `extras` in the backend so users can pass emotion tags. Its auto-regressive decoding can cause repetition loops on long inputs, so testing text-chunking logic inside the `synthesize` method before hitting the model will be essential for stable integration.
+- IndexTTS-2 specializes in auto-regressive zero-shot cloning with emotional control. Upstream describes precise duration control, but the 2025/09/08 README notes that duration control was "not yet enabled in this release"; expose currently available generation controls such as `max_mel_tokens`, `max_text_tokens_per_segment`, and sampling parameters rather than inventing a hard duration API.
+- Emotion controls are exposed by upstream as `emo_audio_prompt`, `emo_alpha`, `emo_vector`, `use_emo_text`, `emo_text`, and `use_random`.
+- The package may download auxiliary upstream dependencies such as semantic codec assets on first model construction. Afterwords should not download the IndexTTS-2 checkpoints itself; require a local `INDEXTTS2_MODEL_DIR` or the default `backends/extras/indextts-2/checkpoints`.
 
 ---

--- a/requirements-indextts.txt
+++ b/requirements-indextts.txt
@@ -1,0 +1,13 @@
+# Optional IndexTTS-2 backend dependencies.
+#
+# Install these only if you plan to use backend=indextts-2 voice profiles:
+#   pip install -r requirements-indextts.txt
+#
+# Download weights separately; the backend does not auto-download IndexTTS-2
+# checkpoints:
+#   huggingface-cli download IndexTeam/IndexTTS-2 \
+#     --local-dir backends/extras/indextts-2/checkpoints
+#
+# IndexTTS-2 uses LicenseRef-Bilibili-IndexTTS, which includes usage
+# restrictions. Review the upstream license before production or commercial use.
+git+https://github.com/index-tts/index-tts.git

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,6 +19,7 @@ def test_register_all_populates_shipped_backends():
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
+        "indextts-2",
     }
 
 
@@ -318,6 +319,117 @@ def test_voxtral_synthesize_uses_voice_extra_and_concatenates_chunks():
     assert audio.shape == (10,)
     assert np.allclose(audio[:4], 0.1)
     assert np.allclose(audio[4:], 0.2)
+
+
+def test_indextts2_prepare_voice_allows_optional_ref_text():
+    from backends.indextts_2 import IndexTTS2Backend
+    from backends.base import RefTextPolicy
+
+    backend = IndexTTS2Backend()
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  ",
+        {"emo_alpha": 0.4, "use_emo_text": True, "emo_text": "calm"},
+    )
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text is None
+    assert prepared.extras["emo_alpha"] == 0.4
+    assert prepared.extras["use_emo_text"] is True
+
+
+def test_indextts2_validate_extras_rejects_unknown_and_invalid_emotion_vector():
+    from backends.indextts_2 import IndexTTS2Backend
+
+    backend = IndexTTS2Backend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="emo_vector must be a sequence of 8"):
+        backend.validate_extras({"emo_vector": [0.1, 0.2]})
+    with pytest.raises(ValueError, match="emo_alpha must be between 0 and 1"):
+        backend.validate_extras({"emo_alpha": 1.5})
+
+
+def test_indextts2_synthesize_passes_emotion_and_duration_controls():
+    import numpy as np
+    from backends.indextts_2 import IndexTTS2Backend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = IndexTTS2Backend()
+    captured_kwargs = {}
+
+    class _CapturingModel:
+        def infer(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return 22050, np.full(12, 1000, dtype=np.int16)
+
+    backend._model = _CapturingModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({
+            "emo_audio_prompt": "/tmp/emo.wav",
+            "emo_alpha": 0.7,
+            "max_mel_tokens": 600,
+            "max_text_tokens_per_segment": 80,
+            "top_p": 0.75,
+        }),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 22050
+    assert audio.dtype == np.float32
+    assert audio.shape == (12,)
+    assert np.allclose(audio, np.full(12, 1000 / 32767, dtype=np.float32))
+    assert captured_kwargs["spk_audio_prompt"] == "/tmp/ref.wav"
+    assert captured_kwargs["text"] == "hello"
+    assert captured_kwargs["output_path"] is None
+    assert captured_kwargs["emo_audio_prompt"] == "/tmp/emo.wav"
+    assert captured_kwargs["emo_alpha"] == 0.7
+    assert captured_kwargs["max_mel_tokens"] == 600
+    assert captured_kwargs["max_text_tokens_per_segment"] == 80
+    assert captured_kwargs["top_p"] == 0.75
+
+
+def test_indextts2_synthesize_rejects_unsupported_lang():
+    from backends.indextts_2 import IndexTTS2Backend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = IndexTTS2Backend()
+    backend._model = object()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='ja'"):
+        backend.synthesize("hello", prepared, lang="ja")
+
+
+def test_indextts2_synthesize_raises_on_empty_output():
+    import numpy as np
+    from backends.indextts_2 import IndexTTS2Backend
+    from backends.base import PreparedVoice, _read_only
+
+    backend = IndexTTS2Backend()
+
+    class _EmptyModel:
+        def infer(self, **kwargs):
+            return 22050, np.array([], dtype=np.float32)
+
+    backend._model = _EmptyModel()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
 
 
 def test_gpt_sovits_requires_reference_text():


### PR DESCRIPTION
## Summary

Adds an optional `indextts-2` backend using upstream `indextts.infer_v2.IndexTTS2` with lazy imports and local-checkpoint loading.

## Details

- Adds emotion extras (`emo_audio_prompt`, `emo_alpha`, `emo_vector`, `use_emo_text`, `emo_text`, `use_random`) and generation controls (`max_mel_tokens`, `max_text_tokens_per_segment`, sampling parameters) exposed through voice profile extras.
- Wires the backend into `register_all()` after XTTS v2.
- Adds `requirements-indextts.txt` and README backend table coverage.
- Updates the stale research note to match upstream API, sample rate, current language support, and `LicenseRef-Bilibili-IndexTTS` licensing.
- Adds mocked tests covering metadata/prepare, extras validation, synthesize kwargs, unsupported language, and empty output.

## Validation

- `PYTHONPATH=. .venv/bin/pytest`