### PR TITLE
feat: add NeuTTS Air backend (on-device CoreML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, and IndexTTS-2.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, and NeuTTS Air.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -234,6 +234,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `gpt-sovits` | MIT | en/zh/ja/ko/yue | 32 kHz | required |
 | `xtts-v2` | CPML, non-commercial only | en/es/fr/de/it/pt/pl/tr/ru/nl/cs/ar/zh/hu/ko/ja/hi | 24 kHz | optional |
 | `indextts-2` | LicenseRef-Bilibili-IndexTTS | en/zh | 22.05 kHz | optional |
+| `neutts-air` | Apache-2.0 | en | 24 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -38,6 +38,7 @@ def register_all() -> None:
     from .gpt_sovits import GPTSoVITSBackend
     from .xtts_v2 import XTTSv2Backend
     from .indextts_2 import IndexTTS2Backend
+    from .neutts_air import NeuTTSAirBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -50,6 +51,7 @@ def register_all() -> None:
     register(GPTSoVITSBackend())
     register(XTTSv2Backend())
     register(IndexTTS2Backend())
+    register(NeuTTSAirBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/neutts_air.py
+++ b/backends/neutts_air.py
@@ -1,0 +1,169 @@
+"""NeuTTS Air backend via Neuphonic's `neutts` package.
+
+NeuTTS Air model weights are Apache-2.0. Review the upstream package and
+model-card licenses before production or commercial use.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.neutts_air")
+
+MODEL_ID = "neuphonic/neutts-air"
+DEFAULT_BACKBONE_REPO = "neuphonic/neutts-air-q4-gguf"
+DEFAULT_CODEC_REPO = "neuphonic/neucodec-onnx-decoder"
+NATIVE_SR = 24000
+
+_ALLOWED_EXTRAS: set[str] = set()
+
+
+def _backbone_repo() -> str:
+    return os.environ.get("NEUTTS_AIR_BACKBONE_REPO", DEFAULT_BACKBONE_REPO)
+
+
+def _backbone_device() -> str:
+    return os.environ.get("NEUTTS_AIR_BACKBONE_DEVICE", "cpu")
+
+
+def _codec_repo() -> str:
+    return os.environ.get("NEUTTS_AIR_CODEC_REPO", DEFAULT_CODEC_REPO)
+
+
+def _codec_device() -> str:
+    return os.environ.get("NEUTTS_AIR_CODEC_DEVICE", "cpu")
+
+
+def _language() -> str | None:
+    return os.environ.get("NEUTTS_AIR_LANGUAGE")
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    audio = np.asarray(audio)
+    if np.issubdtype(audio.dtype, np.integer):
+        max_value = float(np.iinfo(audio.dtype).max)
+        audio = audio.astype(np.float32) / max_value
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+class NeuTTSAirBackend(BackendBase):
+    name = "neutts-air"
+    display_name = "NeuTTS Air (Apache-2.0)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en",)
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._backbone_repo = _backbone_repo()
+        self._backbone_device = _backbone_device()
+        self._codec_repo = _codec_repo()
+        self._codec_device = _codec_device()
+        self._language = _language()
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                from neutts import NeuTTS
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-neutts-air.txt"
+                )
+                log.warning("NeuTTS Air unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            backbone_repo = _backbone_repo()
+            backbone_device = _backbone_device()
+            codec_repo = _codec_repo()
+            codec_device = _codec_device()
+            language = _language()
+
+            log.info(
+                "loading %s with backbone %s on %s and codec %s on %s ...",
+                MODEL_ID,
+                backbone_repo,
+                backbone_device,
+                codec_repo,
+                codec_device,
+            )
+            kwargs = {
+                "backbone_repo": backbone_repo,
+                "backbone_device": backbone_device,
+                "codec_repo": codec_repo,
+                "codec_device": codec_device,
+            }
+            if language:
+                kwargs["language"] = language
+            self._model = NeuTTS(**kwargs)
+            self._backbone_repo = backbone_repo
+            self._backbone_device = backbone_device
+            self._codec_repo = codec_repo
+            self._codec_device = codec_device
+            self._language = language
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"NeuTTS Air does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        prepared_extras = dict(extras)
+        if self._model is not None:
+            prepared_extras["ref_codes"] = self._model.encode_reference(ref_audio_path)
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(prepared_extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"NeuTTS Air is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("NeuTTSAirBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"neutts-air does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        ref_codes = prepared.extras.get("ref_codes")
+        if ref_codes is None:
+            ref_codes = self._model.encode_reference(prepared.ref_audio_path)
+
+        audio = _to_numpy(self._model.infer(text, ref_codes, prepared.ref_text or ""))
+        if not audio.size:
+            raise RuntimeError("NeuTTS Air produced no output")
+        return audio.astype(np.float32, copy=False), NATIVE_SR

--- a/docs/research/tts-backends/neutts-air.md
+++ b/docs/research/tts-backends/neutts-air.md
@@ -1,34 +1,42 @@
 ## NeuTTS Air
 
-**Repo:** Proprietary (Neuphonic SDK/CLI)
-**License:** Proprietary
-**Size:** 0.748B, 1.5 GB
+**Repo:** https://github.com/neuphonic/neutts
+**Model:** https://huggingface.co/neuphonic/neutts-air
+**License:** Apache-2.0 for NeuTTS Air model weights; the `neutts` package also
+ships NeuTTS Nano models under the NeuTTS Open License 1.0.
+**Size:** ~0.7B params / 1.5 GB BF16; Q4/Q8 GGUF quantizations are available.
 **Sample rate:** 24000
 **Languages:** en-only
-**Apple Silicon path:** CPU-only — Note: This is an on-device embedded engine packaged with compiled libraries specifically optimized to run without cloud reliance or heavy GPU scaffolding.
+**Apple Silicon path:** CPU-first GGUF via `llama-cpp-python` + NeuCodec. This is
+not CoreML; upstream recommends Apple Accelerate builds for `llama-cpp-python`.
 
 ### Install
 ```bash
-# Requires an SDK license and proprietary wheel file from Neuphonic
-pip install neuphonic-air-sdk
+# Requires espeak-ng as a system dependency.
+brew install espeak-ng
+
+pip install "neutts[llama,onnx]"
 ```
 
 ### Model download
 ```bash
-# Provided securely via SDK initialization or authenticated endpoint
-neuphonic download --model air-0.7b
+# No separate SDK-authenticated download step. The neutts package downloads from
+# Hugging Face on first load unless model files are already cached.
 ```
 Disk: 1.5 GB
 
 ### Python API for cloning
 ```python
-from neuphonic import NeuTTS
+from neutts import NeuTTS
 
-model = NeuTTS(model_name="air-0.7b")
-audio = model.synthesize(
-    text="This is a test sentence.",
-    ref_audio="reference.wav"
+tts = NeuTTS(
+    backbone_repo="neuphonic/neutts-air-q4-gguf",
+    backbone_device="cpu",
+    codec_repo="neuphonic/neucodec-onnx-decoder",
+    codec_device="cpu",
 )
+ref_codes = tts.encode_reference("reference.wav")
+audio = tts.infer("This is a test sentence.", ref_codes, "reference transcript")
 ```
 
 ### Backend protocol skeleton
@@ -37,9 +45,9 @@ audio = model.synthesize(
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class NeuTTSAirBackend(BackendBase):
-    name = "neutts_air"
+    name = "neutts-air"
     sample_rate = 24000
-    ref_text_policy = RefTextPolicy.IGNORED
+    ref_text_policy = RefTextPolicy.OPTIONAL
     supported_langs = ("en",)
 
     def load(self): ...
@@ -48,4 +56,12 @@ class NeuTTSAirBackend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- As a proprietary model running highly compressed CoreML or specialized CPU operations, NeuTTS Air sidesteps standard PyTorch/MPS bottlenecks completely. Its integration will likely be the most stable of the bunch for the M5 due to its specialized environment. The main quirk here is managing the SDK authentication logic (if required) within the `load` function, and verifying that threading models inside afterwords don't conflict with Neuphonic's compiled C++ bindings execution lock.
+- NeuTTS Air is open-weight and local; no Neuphonic SDK authentication is
+  required.
+- Upstream expects reference audio plus reference text. Afterwords can treat the
+  transcript as optional for profile compatibility, but quality is best when it
+  is present.
+- Pre-encode references in `prepare_voice()` with `encode_reference()` so normal
+  synthesis only calls `infer(text, ref_codes, ref_text)`.
+- Keep imports lazy in `load()` because `neutts` pulls in Torch, Transformers,
+  llama-cpp-python, phonemizer, and codec dependencies.

--- a/requirements-neutts-air.txt
+++ b/requirements-neutts-air.txt
@@ -1,0 +1,7 @@
+# Optional NeuTTS Air backend dependencies.
+# Install espeak-ng separately on macOS: brew install espeak-ng
+# For faster GGUF CPU inference on Apple Silicon, rebuild llama-cpp-python with
+# Accelerate as described by Neuphonic:
+# CMAKE_ARGS="-DGGML_METAL=OFF -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Apple" \
+#   pip install "neutts[llama]" --force-reinstall --no-cache-dir
+neutts[llama,onnx]>=1.2.1,<1.3

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,7 +19,7 @@ def test_register_all_populates_shipped_backends():
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
-        "indextts-2",
+        "indextts-2", "neutts-air",
     }
 
 
@@ -428,6 +428,110 @@ def test_indextts2_synthesize_raises_on_empty_output():
         extras=_read_only({}),
     )
 
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_neutts_air_metadata():
+    from backends.neutts_air import NeuTTSAirBackend
+
+    backend = NeuTTSAirBackend()
+
+    assert backend.name == "neutts-air"
+    assert backend.display_name == "NeuTTS Air (Apache-2.0)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en",)
+
+
+def test_neutts_air_prepare_voice_preencodes_reference_when_loaded():
+    import numpy as np
+    from backends.neutts_air import NeuTTSAirBackend
+
+    backend = NeuTTSAirBackend()
+
+    class _NeuTTS:
+        def encode_reference(self, ref_audio_path):
+            assert ref_audio_path == "/tmp/ref.wav"
+            return np.array([1, 2, 3], dtype=np.int64)
+
+    backend._model = _NeuTTS()
+
+    prepared = backend.prepare_voice("/tmp/ref.wav", " reference text ", {})
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference text"
+    assert np.array_equal(prepared.extras["ref_codes"], np.array([1, 2, 3]))
+
+
+def test_neutts_air_rejects_unknown_extras():
+    from backends.neutts_air import NeuTTSAirBackend
+
+    backend = NeuTTSAirBackend()
+
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"temperature": 0.8})
+
+
+def test_neutts_air_synthesize_uses_preencoded_reference():
+    import numpy as np
+    from backends.neutts_air import NeuTTSAirBackend
+
+    backend = NeuTTSAirBackend()
+    captured = {}
+
+    class _NeuTTS:
+        def encode_reference(self, ref_audio_path):
+            raise AssertionError("preencoded ref_codes should be reused")
+
+        def infer(self, text, ref_codes, ref_text):
+            captured["text"] = text
+            captured["ref_codes"] = ref_codes
+            captured["ref_text"] = ref_text
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    ref_codes = np.array([4, 5, 6], dtype=np.int64)
+    backend._model = _NeuTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference text",
+        extras=_read_only({"ref_codes": ref_codes}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured == {
+        "text": "hello",
+        "ref_codes": ref_codes,
+        "ref_text": "reference text",
+    }
+
+
+def test_neutts_air_synthesize_rejects_unsupported_lang_and_empty_output():
+    import numpy as np
+    from backends.neutts_air import NeuTTSAirBackend
+
+    backend = NeuTTSAirBackend()
+
+    class _NeuTTS:
+        def encode_reference(self, ref_audio_path):
+            return [1]
+
+        def infer(self, text, ref_codes, ref_text):
+            return np.array([], dtype=np.float32)
+
+    backend._model = _NeuTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='fr'"):
+        backend.synthesize("bonjour", prepared, lang="fr")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary
- add optional `neutts-air` backend using Neuphonic's current `neutts.NeuTTS` API
- register the backend and add mocked backend tests
- add optional requirements plus README/backend table updates
- refresh stale research notes: upstream is now `neuphonic/neutts`; NeuTTS Air model weights are Apache-2.0 and the current path is CPU/GGUF rather than CoreML

## Tests
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`