### PR TITLE
feat: add Spark-TTS backend (LLM + BiCodec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -235,6 +235,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `xtts-v2` | CPML, non-commercial only | en/es/fr/de/it/pt/pl/tr/ru/nl/cs/ar/zh/hu/ko/ja/hi | 24 kHz | optional |
 | `indextts-2` | LicenseRef-Bilibili-IndexTTS | en/zh | 22.05 kHz | optional |
 | `neutts-air` | Apache-2.0 | en | 24 kHz | optional |
+| `spark-tts` | Apache-2.0 code; CC-BY-NC-SA 4.0 weights | en/zh | 24 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -248,7 +249,8 @@ GET  /health
           "loaded_backends": {"qwen3-0.6b": {"loaded":true, "voice_count":..., "supported_langs":[...]}, ...}}
 
        Current backend ids:
-       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2
+       qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
+       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -39,6 +39,7 @@ def register_all() -> None:
     from .xtts_v2 import XTTSv2Backend
     from .indextts_2 import IndexTTS2Backend
     from .neutts_air import NeuTTSAirBackend
+    from .spark_tts import SparkTTSBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -52,6 +53,7 @@ def register_all() -> None:
     register(XTTSv2Backend())
     register(IndexTTS2Backend())
     register(NeuTTSAirBackend())
+    register(SparkTTSBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/spark_tts.py
+++ b/backends/spark_tts.py
@@ -1,0 +1,182 @@
+"""Spark-TTS backend via SparkAudio/Spark-TTS.
+
+Spark-TTS upstream code is Apache-2.0, but the Spark-TTS-0.5B model weights
+are CC-BY-NC-SA 4.0 and non-commercial. Review upstream license terms before
+production use.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.spark_tts")
+
+MODEL_ID = "SparkAudio/Spark-TTS-0.5B"
+NATIVE_SR = 24000
+DEFAULT_BASE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "spark-tts",
+)
+DEFAULT_REPO_DIR = os.path.join(DEFAULT_BASE_DIR, "Spark-TTS")
+DEFAULT_MODEL_DIR = os.path.join(DEFAULT_BASE_DIR, "Spark-TTS-0.5B")
+
+_ALLOWED_EXTRAS = {"temperature", "top_k", "top_p"}
+
+
+def _repo_dir() -> str:
+    return os.environ.get("SPARK_TTS_REPO_DIR", DEFAULT_REPO_DIR)
+
+
+def _model_dir() -> str:
+    return os.environ.get("SPARK_TTS_MODEL_DIR", DEFAULT_MODEL_DIR)
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("SPARK_TTS_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda:0"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    audio = np.asarray(audio)
+    if np.issubdtype(audio.dtype, np.integer):
+        max_value = float(np.iinfo(audio.dtype).max)
+        audio = audio.astype(np.float32) / max_value
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+class SparkTTSBackend(BackendBase):
+    name = "spark-tts"
+    display_name = "Spark-TTS-0.5B (CC-BY-NC-SA 4.0 weights)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en", "zh")
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._repo_dir = _repo_dir()
+        self._model_dir = _model_dir()
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            repo_dir = _repo_dir()
+            model_dir = _model_dir()
+            if os.path.isdir(repo_dir) and repo_dir not in sys.path:
+                sys.path.insert(0, repo_dir)
+            if not os.path.exists(os.path.join(model_dir, "config.yaml")):
+                self._unavailable_reason = (
+                    "Spark-TTS model directory not found. Download "
+                    f"{MODEL_ID} to {model_dir!r} or set SPARK_TTS_MODEL_DIR."
+                )
+                log.warning("Spark-TTS unavailable: %s", self._unavailable_reason)
+                return
+
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from cli.SparkTTS import SparkTTS
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; install "
+                    "requirements-spark-tts.txt and clone Spark-TTS to "
+                    f"{repo_dir!r} or set SPARK_TTS_REPO_DIR"
+                )
+                log.warning("Spark-TTS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            device = _device(torch)
+            log.info("loading %s from %s on %s ...", MODEL_ID, model_dir, device)
+            self._model = SparkTTS(Path(model_dir), device=torch.device(device))
+            self._repo_dir = repo_dir
+            self._model_dir = model_dir
+            self._device = device
+            self.sample_rate = int(getattr(self._model, "sample_rate", NATIVE_SR))
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"Spark-TTS does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in ("temperature", "top_p"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"Spark-TTS {key} must be numeric; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"Spark-TTS {key} must be > 0; got {value!r}")
+        top_k = extras.get("top_k")
+        if top_k is not None and (not isinstance(top_k, int) or isinstance(top_k, bool)):
+            raise ValueError(f"Spark-TTS top_k must be an integer; got {top_k!r}")
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"Spark-TTS top_k must be > 0; got {top_k!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"Spark-TTS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("SparkTTSBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"spark-tts does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        kwargs = {
+            "text": text,
+            "prompt_speech_path": Path(prepared.ref_audio_path),
+            "prompt_text": prepared.ref_text,
+        }
+        for key in ("temperature", "top_k", "top_p"):
+            if key in prepared.extras:
+                kwargs[key] = prepared.extras[key]
+
+        audio = _to_numpy(self._model.inference(**kwargs))
+        if not audio.size:
+            raise RuntimeError("Spark-TTS produced no output")
+        return audio.astype(np.float32, copy=False), int(getattr(self._model, "sample_rate", self.sample_rate))

--- a/docs/research/tts-backends/spark-tts.md
+++ b/docs/research/tts-backends/spark-tts.md
@@ -1,33 +1,36 @@
 ## Spark-TTS
 
-**Repo:** https://github.com/Spark-TTS/Spark-TTS
-**License:** Open Source
+**Repo:** https://github.com/SparkAudio/Spark-TTS
+**License:** Code is Apache-2.0; `SparkAudio/Spark-TTS-0.5B` weights are CC-BY-NC-SA 4.0, non-commercial
 **Size:** 0.5B, 2.0 GB
 **Sample rate:** 24000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: Model architecture leverages a decoupled token approach which translates nicely to standard PyTorch MPS ops.
+**Languages:** en/zh, with cross-lingual and code-switching cloning examples upstream
+**Apple Silicon path:** PyTorch+MPS via `SPARK_TTS_DEVICE=mps`; upstream primarily documents Linux/CUDA, so expect occasional `PYTORCH_ENABLE_MPS_FALLBACK=1` use on Apple Silicon.
 
 ### Install
 ```bash
-git clone https://github.com/Spark-TTS/Spark-TTS.git
+git clone https://github.com/SparkAudio/Spark-TTS.git
 cd Spark-TTS
 pip install -r requirements.txt
 ```
 
 ### Model download
 ```bash
-huggingface-cli download Spark-TTS/Spark-TTS-0.5B
+huggingface-cli download SparkAudio/Spark-TTS-0.5B
 ```
 Disk: 2.0 GB
 
 ### Python API for cloning
 ```python
-from sparktts import SparkTTS
+from pathlib import Path
+import torch
+from cli.SparkTTS import SparkTTS
 
-model = SparkTTS.from_pretrained("Spark-TTS/Spark-TTS-0.5B").to("mps")
-wav_out = model.generate(
+model = SparkTTS(Path("pretrained_models/Spark-TTS-0.5B"), device=torch.device("mps"))
+wav_out = model.inference(
     text="This is a test sentence.",
-    prompt_audio="reference.wav"
+    prompt_speech_path=Path("reference.wav"),
+    prompt_text=None,
 )
 ```
 
@@ -37,10 +40,10 @@ wav_out = model.generate(
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class SparkTTSBackend(BackendBase):
-    name = "spark_tts"
+    name = "spark-tts"
     sample_rate = 24000
     ref_text_policy = RefTextPolicy.OPTIONAL
-    supported_langs = ("multilingual",)
+    supported_langs = ("en", "zh")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...

--- a/requirements-spark-tts.txt
+++ b/requirements-spark-tts.txt
@@ -1,0 +1,28 @@
+# Optional Spark-TTS backend dependencies.
+#
+# Install these only if you plan to use backend=spark-tts voice profiles:
+#   pip install -r requirements-spark-tts.txt
+#
+# Clone the Spark-TTS source separately; the backend adds this default path to
+# PYTHONPATH when it exists, or set SPARK_TTS_REPO_DIR:
+#   git clone https://github.com/SparkAudio/Spark-TTS.git \
+#     backends/extras/spark-tts/Spark-TTS
+#
+# Download weights separately; the backend does not auto-download them:
+#   huggingface-cli download SparkAudio/Spark-TTS-0.5B \
+#     --local-dir backends/extras/spark-tts/Spark-TTS-0.5B
+#
+# Spark-TTS code is Apache-2.0. Spark-TTS-0.5B weights are CC-BY-NC-SA 4.0
+# and non-commercial per the Hugging Face model card.
+einops==0.8.1
+einx==0.3.0
+numpy==2.2.3
+omegaconf==2.3.0
+packaging==24.2
+safetensors==0.5.2
+soundfile==0.12.1
+soxr==0.5.0.post1
+torch==2.5.1
+torchaudio==2.5.1
+tqdm==4.66.5
+transformers==4.46.2

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,7 +19,7 @@ def test_register_all_populates_shipped_backends():
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
-        "indextts-2", "neutts-air",
+        "indextts-2", "neutts-air", "spark-tts",
     }
 
 
@@ -532,6 +532,109 @@ def test_neutts_air_synthesize_rejects_unsupported_lang_and_empty_output():
 
     with pytest.raises(ValueError, match="does not support lang='fr'"):
         backend.synthesize("bonjour", prepared, lang="fr")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_spark_tts_metadata():
+    from backends.spark_tts import SparkTTSBackend
+
+    backend = SparkTTSBackend()
+
+    assert backend.name == "spark-tts"
+    assert backend.display_name == "Spark-TTS-0.5B (CC-BY-NC-SA 4.0 weights)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en", "zh")
+
+
+def test_spark_tts_prepare_voice_allows_optional_ref_text():
+    from backends.spark_tts import SparkTTSBackend
+
+    backend = SparkTTSBackend()
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  ",
+        {"temperature": 0.7, "top_k": 40, "top_p": 0.9},
+    )
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text is None
+    assert prepared.extras["temperature"] == 0.7
+    assert prepared.extras["top_k"] == 40
+    assert prepared.extras["top_p"] == 0.9
+
+
+def test_spark_tts_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.spark_tts import SparkTTSBackend
+
+    backend = SparkTTSBackend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="top_k must be an integer"):
+        backend.validate_extras({"top_k": 12.5})
+    with pytest.raises(ValueError, match="temperature must be > 0"):
+        backend.validate_extras({"temperature": 0})
+
+
+def test_spark_tts_synthesize_calls_inference_with_prompt_and_sampling_extras():
+    import numpy as np
+    from pathlib import Path
+    from backends.spark_tts import SparkTTSBackend
+
+    backend = SparkTTSBackend()
+    captured_kwargs = {}
+
+    class _SparkTTS:
+        sample_rate = 24000
+
+        def inference(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    backend._model = _SparkTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference transcript",
+        extras=_read_only({"temperature": 0.65, "top_k": 25, "top_p": 0.85}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured_kwargs == {
+        "text": "hello",
+        "prompt_speech_path": Path("/tmp/ref.wav"),
+        "prompt_text": "reference transcript",
+        "temperature": 0.65,
+        "top_k": 25,
+        "top_p": 0.85,
+    }
+
+
+def test_spark_tts_synthesize_rejects_unsupported_lang_and_empty_output():
+    import numpy as np
+    from backends.spark_tts import SparkTTSBackend
+
+    backend = SparkTTSBackend()
+
+    class _SparkTTS:
+        sample_rate = 24000
+
+        def inference(self, **kwargs):
+            return np.array([], dtype=np.float32)
+
+    backend._model = _SparkTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='ja'"):
+        backend.synthesize("konnichiwa", prepared, lang="ja")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary
- add optional Spark-TTS backend wrapping SparkAudio's LLM + BiCodec inference API
- register `spark-tts`, document install/model locations, and add optional requirements
- refresh Spark-TTS research notes and README backend table with verified code/model licenses
- add mocked backend tests for metadata, optional ref text, extras validation, inference kwargs, language rejection, and empty output

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`

## License notes
- GitHub source license: Apache-2.0
- `SparkAudio/Spark-TTS-0.5B` weights: CC-BY-NC-SA 4.0, non-commercial per the Hugging Face model card
