### PR TITLE
feat: add Dia2 backend (Nari Labs dialogue TTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, and NeuTTS Air.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, and Dia2.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -236,6 +236,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `indextts-2` | LicenseRef-Bilibili-IndexTTS | en/zh | 22.05 kHz | optional |
 | `neutts-air` | Apache-2.0 | en | 24 kHz | optional |
 | `spark-tts` | Apache-2.0 code; CC-BY-NC-SA 4.0 weights | en/zh | 24 kHz | optional |
+| `dia2` | Apache-2.0 | en | 44 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -250,7 +251,7 @@ GET  /health
 
        Current backend ids:
        qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
-       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts
+       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -40,6 +40,7 @@ def register_all() -> None:
     from .indextts_2 import IndexTTS2Backend
     from .neutts_air import NeuTTSAirBackend
     from .spark_tts import SparkTTSBackend
+    from .dia2 import Dia2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -54,6 +55,7 @@ def register_all() -> None:
     register(IndexTTS2Backend())
     register(NeuTTSAirBackend())
     register(SparkTTSBackend())
+    register(Dia2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/dia2.py
+++ b/backends/dia2.py
@@ -1,0 +1,222 @@
+"""Dia2 backend via Nari Labs' streaming dialogue TTS runtime.
+
+Dia2 code and model weights are Apache-2.0. Upstream is CUDA-first; Apple
+Silicon users may need to set DIA2_DEVICE=mps/cpu depending on local PyTorch
+support and upstream compatibility.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.dia2")
+
+MODEL_ID = "nari-labs/Dia2-2B"
+NATIVE_SR = 44000
+
+_ALLOWED_EXTRAS = {
+    "temperature",
+    "top_k",
+    "text_temperature",
+    "text_top_k",
+    "audio_temperature",
+    "audio_top_k",
+    "cfg_scale",
+    "cfg_filter_k",
+    "initial_padding",
+    "use_cuda_graph",
+    "use_torch_compile",
+    "include_prefix",
+    "verbose",
+}
+
+
+def _model_id() -> str:
+    return os.environ.get("DIA2_MODEL_ID", MODEL_ID)
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("DIA2_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _dtype() -> str:
+    return os.environ.get("DIA2_DTYPE", "bfloat16")
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    audio = np.asarray(audio)
+    if np.issubdtype(audio.dtype, np.integer):
+        max_value = float(np.iinfo(audio.dtype).max)
+        audio = audio.astype(np.float32) / max_value
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _script_for_speaker_one(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("[S1]") or stripped.startswith("[S2]"):
+        return stripped
+    return f"[S1] {stripped}"
+
+
+class Dia2Backend(BackendBase):
+    name = "dia2"
+    display_name = "Dia2 (Nari Labs Apache-2.0)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en",)
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._GenerationConfig = None
+        self._PrefixConfig = None
+        self._SamplingConfig = None
+        self._model_id = _model_id()
+        self._device = None
+        self._dtype = _dtype()
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from dia2 import Dia2, GenerationConfig, PrefixConfig, SamplingConfig
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-dia2.txt"
+                )
+                log.warning("Dia2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            model_id = _model_id()
+            device = _device(torch)
+            dtype = _dtype()
+            log.info("loading %s on %s with dtype=%s ...", model_id, device, dtype)
+            self._model = Dia2.from_repo(model_id, device=device, dtype=dtype)
+            self._GenerationConfig = GenerationConfig
+            self._PrefixConfig = PrefixConfig
+            self._SamplingConfig = SamplingConfig
+            self._model_id = model_id
+            self.model_id = model_id
+            self._device = device
+            self._dtype = dtype
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"Dia2 does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in ("temperature", "text_temperature", "audio_temperature", "cfg_scale"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, (int, float)):
+                raise ValueError(f"Dia2 {key} must be numeric; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"Dia2 {key} must be > 0; got {value!r}")
+        for key in ("top_k", "text_top_k", "audio_top_k", "cfg_filter_k", "initial_padding"):
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"Dia2 {key} must be an integer; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"Dia2 {key} must be > 0; got {value!r}")
+        for key in ("use_cuda_graph", "use_torch_compile", "include_prefix", "verbose"):
+            value = extras.get(key)
+            if value is not None and not isinstance(value, bool):
+                raise ValueError(f"Dia2 {key} must be boolean; got {value!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def _generation_config(self, extras: Mapping[str, object]):
+        if self._GenerationConfig is None or self._PrefixConfig is None or self._SamplingConfig is None:
+            raise RuntimeError("Dia2Backend.synthesize called before load()")
+
+        temperature = float(extras.get("temperature", 0.8))
+        top_k = int(extras.get("top_k", 50))
+        text_sampling = self._SamplingConfig(
+            temperature=float(extras.get("text_temperature", temperature)),
+            top_k=int(extras.get("text_top_k", top_k)),
+        )
+        audio_sampling = self._SamplingConfig(
+            temperature=float(extras.get("audio_temperature", temperature)),
+            top_k=int(extras.get("audio_top_k", top_k)),
+        )
+        return self._GenerationConfig(
+            text=text_sampling,
+            audio=audio_sampling,
+            cfg_scale=float(extras.get("cfg_scale", 2.0)),
+            cfg_filter_k=int(extras.get("cfg_filter_k", 50)),
+            initial_padding=int(extras.get("initial_padding", 2)),
+            prefix=self._PrefixConfig(
+                speaker_1=None,
+                speaker_2=None,
+                include_audio=bool(extras.get("include_prefix", False)),
+            ),
+            use_cuda_graph=bool(extras.get("use_cuda_graph", False)),
+            use_torch_compile=bool(extras.get("use_torch_compile", False)),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"Dia2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("Dia2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"dia2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        config = self._generation_config(prepared.extras)
+        result = self._model.generate(
+            _script_for_speaker_one(text),
+            config=config,
+            prefix_speaker_1=prepared.ref_audio_path,
+            include_prefix=bool(prepared.extras.get("include_prefix", False)),
+            verbose=bool(prepared.extras.get("verbose", False)),
+        )
+        waveform = getattr(result, "waveform", result)
+        audio = _to_numpy(waveform)
+        if not audio.size:
+            raise RuntimeError("Dia2 produced no output")
+        return audio.astype(np.float32, copy=False), int(getattr(result, "sample_rate", self.sample_rate))

--- a/docs/research/tts-backends/dia2.md
+++ b/docs/research/tts-backends/dia2.md
@@ -1,32 +1,34 @@
 ## Dia2
 
-**Repo:** https://github.com/NariLabs/Dia2
+**Repo:** https://github.com/nari-labs/dia2
 **License:** Apache-2.0
-**Size:** 1.6B, 5.0 GB
+**Size:** 1B / 2B variants
 **Sample rate:** 44000
 **Languages:** en-only
-**Apple Silicon path:** PyTorch+MPS — Note: Handles dialogue formatting natively; larger parameter count but highly optimized for single-stream text.
+**Apple Silicon path:** PyTorch runtime; upstream is CUDA-first and documents CUDA 12.8+ for best support. Try `DIA2_DEVICE=mps` or `DIA2_DEVICE=cpu` locally, but expect upstream compatibility to lag CUDA. Handles dialogue formatting natively and supports realtime/streaming-oriented generation.
 
 ### Install
 ```bash
-pip install dia-tts torch torchaudio
+pip install -r requirements-dia2.txt
 ```
 
 ### Model download
 ```bash
-huggingface-cli download NariLabs/Dia2
+huggingface-cli download nari-labs/Dia2-2B
 ```
-Disk: 5.0 GB
+Variants: `nari-labs/Dia2-1B`, `nari-labs/Dia2-2B`
 
 ### Python API for cloning
 ```python
-from dia import DiaModel
+from dia2 import Dia2, GenerationConfig, PrefixConfig, SamplingConfig
 
-dia = DiaModel.from_pretrained("NariLabs/Dia2").to("mps")
-audio_data = dia.generate(
-    "This is a test sentence.", 
-    audio_prompt="reference.wav"
+dia = Dia2.from_repo("nari-labs/Dia2-2B", device="cuda", dtype="bfloat16")
+config = GenerationConfig(
+    audio=SamplingConfig(temperature=0.8, top_k=50),
+    prefix=PrefixConfig(include_audio=False),
 )
+result = dia.generate("[S1] This is a test sentence.", config=config, prefix_speaker_1="reference.wav")
+audio_data = result.waveform
 ```
 
 ### Backend protocol skeleton
@@ -35,9 +37,9 @@ audio_data = dia.generate(
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class Dia2Backend(BackendBase):
-    name = "dia_2"
+    name = "dia2"
     sample_rate = 44000
-    ref_text_policy = RefTextPolicy.IGNORED
+    ref_text_policy = RefTextPolicy.OPTIONAL
     supported_langs = ("en",)
 
     def load(self): ...
@@ -46,6 +48,9 @@ class Dia2Backend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- Dia2 is optimized for multi-speaker dialogues and supports embedded nonverbal tags like `(laughs)`. In your afterwords pipeline, you can largely ignore `ref_text` and just pass `audio_prompt`. However, when sending the `text` string to `synthesize`, you should be aware of the `[S1]` / `[S2]` speaker tag formatting that Dia2 expects. You may need to prepend your input string with `[S1]` implicitly within the backend to ensure it treats the cloned reference as the primary active speaker.
+- Dia2 is optimized for multi-speaker dialogues and supports embedded nonverbal tags like `(laughs)`.
+- Dia2 expects `[S1]` / `[S2]` speaker tag formatting. The backend should prepend `[S1]` when callers provide plain text.
+- Voice conditioning is passed as `prefix_speaker_1`; upstream transcribes prefix audio internally.
+- The implementation should keep Dia2 imports lazy in `load()` and must not download weights during unit tests.
 
 ---

--- a/requirements-dia2.txt
+++ b/requirements-dia2.txt
@@ -1,0 +1,12 @@
+# Optional Dia2 backend dependencies.
+# Upstream currently recommends uv/CUDA, but this file keeps Afterwords' optional
+# backend install pattern consistent.
+git+https://github.com/nari-labs/dia2.git
+torch>=2.8.0
+numpy>=2.1.0,<3.0
+transformers>=4.55.3
+safetensors==0.5.3
+huggingface-hub>=0.24.7
+sphn>=0.2.0
+soundfile>=0.12.1
+whisper-timestamped>=1.14.2

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,7 +19,7 @@ def test_register_all_populates_shipped_backends():
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
-        "indextts-2", "neutts-air", "spark-tts",
+        "indextts-2", "neutts-air", "spark-tts", "dia2",
     }
 
 
@@ -635,6 +635,153 @@ def test_spark_tts_synthesize_rejects_unsupported_lang_and_empty_output():
 
     with pytest.raises(ValueError, match="does not support lang='ja'"):
         backend.synthesize("konnichiwa", prepared, lang="ja")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_dia2_metadata():
+    from backends.dia2 import Dia2Backend
+
+    backend = Dia2Backend()
+
+    assert backend.name == "dia2"
+    assert backend.display_name == "Dia2 (Nari Labs Apache-2.0)"
+    assert backend.sample_rate == 44000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en",)
+
+
+def test_dia2_prepare_voice_allows_optional_ref_text():
+    from backends.dia2 import Dia2Backend
+
+    backend = Dia2Backend()
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  reference transcript  ",
+        {"temperature": 0.7, "top_k": 40, "cfg_scale": 3.0},
+    )
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference transcript"
+    assert prepared.extras["temperature"] == 0.7
+    assert prepared.extras["top_k"] == 40
+    assert prepared.extras["cfg_scale"] == 3.0
+
+
+def test_dia2_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.dia2 import Dia2Backend
+
+    backend = Dia2Backend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="top_k must be an integer"):
+        backend.validate_extras({"top_k": 12.5})
+    with pytest.raises(ValueError, match="temperature must be > 0"):
+        backend.validate_extras({"temperature": 0})
+    with pytest.raises(ValueError, match="use_cuda_graph must be boolean"):
+        backend.validate_extras({"use_cuda_graph": "yes"})
+
+
+def test_dia2_synthesize_builds_dialogue_script_and_config():
+    import numpy as np
+    from backends.dia2 import Dia2Backend
+
+    backend = Dia2Backend()
+    captured = {}
+
+    class _SamplingConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _PrefixConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _GenerationConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _Dia2:
+        def generate(self, script, **kwargs):
+            captured["script"] = script
+            captured.update(kwargs)
+            return type(
+                "Result",
+                (),
+                {"waveform": np.array([[0.1, -0.2]], dtype=np.float64), "sample_rate": 44000},
+            )()
+
+    backend._model = _Dia2()
+    backend._SamplingConfig = _SamplingConfig
+    backend._PrefixConfig = _PrefixConfig
+    backend._GenerationConfig = _GenerationConfig
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({
+            "text_temperature": 0.55,
+            "text_top_k": 35,
+            "audio_temperature": 0.75,
+            "audio_top_k": 45,
+            "cfg_scale": 4.0,
+            "cfg_filter_k": 60,
+            "initial_padding": 3,
+            "use_cuda_graph": True,
+            "include_prefix": False,
+        }),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 44000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured["script"] == "[S1] hello"
+    assert captured["prefix_speaker_1"] == "/tmp/ref.wav"
+    assert captured["include_prefix"] is False
+    config = captured["config"]
+    assert config.kwargs["text"].kwargs == {"temperature": 0.55, "top_k": 35}
+    assert config.kwargs["audio"].kwargs == {"temperature": 0.75, "top_k": 45}
+    assert config.kwargs["cfg_scale"] == 4.0
+    assert config.kwargs["cfg_filter_k"] == 60
+    assert config.kwargs["initial_padding"] == 3
+    assert config.kwargs["use_cuda_graph"] is True
+
+
+def test_dia2_synthesize_rejects_unsupported_lang_and_empty_output():
+    import numpy as np
+    from backends.dia2 import Dia2Backend
+
+    backend = Dia2Backend()
+
+    class _SamplingConfig:
+        def __init__(self, **kwargs):
+            pass
+
+    class _PrefixConfig:
+        def __init__(self, **kwargs):
+            pass
+
+    class _GenerationConfig:
+        def __init__(self, **kwargs):
+            pass
+
+    class _Dia2:
+        def generate(self, script, **kwargs):
+            return type("Result", (), {"waveform": np.array([], dtype=np.float32)})()
+
+    backend._model = _Dia2()
+    backend._SamplingConfig = _SamplingConfig
+    backend._PrefixConfig = _PrefixConfig
+    backend._GenerationConfig = _GenerationConfig
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='fr'"):
+        backend.synthesize("bonjour", prepared, lang="fr")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary
- add optional Dia2 backend with lazy Dia2/PyTorch imports, dialogue speaker tagging, prefix voice conditioning, and sampling/config extras
- register `dia2` with the backend registry and document it in README/research notes
- add mocked backend tests and optional dependency requirements

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`
