### PR TITLE
feat: add YourTTS backend (Coqui VITS multilingual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, and Dia2.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, Dia2, and YourTTS.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -237,6 +237,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `neutts-air` | Apache-2.0 | en | 24 kHz | optional |
 | `spark-tts` | Apache-2.0 code; CC-BY-NC-SA 4.0 weights | en/zh | 24 kHz | optional |
 | `dia2` | Apache-2.0 | en | 44 kHz | optional |
+| `yourtts` | Open source | en/fr/pt-BR | 16 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -251,7 +252,7 @@ GET  /health
 
        Current backend ids:
        qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
-       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2
+       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -41,6 +41,7 @@ def register_all() -> None:
     from .neutts_air import NeuTTSAirBackend
     from .spark_tts import SparkTTSBackend
     from .dia2 import Dia2Backend
+    from .yourtts import YourTTSBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -56,6 +57,7 @@ def register_all() -> None:
     register(NeuTTSAirBackend())
     register(SparkTTSBackend())
     register(Dia2Backend())
+    register(YourTTSBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/yourtts.py
+++ b/backends/yourtts.py
@@ -1,0 +1,131 @@
+"""YourTTS backend via Coqui TTS.
+
+YourTTS is Coqui's older lightweight multilingual VITS-based zero-shot cloning
+model. It uses the same ``TTS.api.TTS`` package as XTTS v2, but the model is
+open source and outputs 16 kHz audio.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.yourtts")
+
+MODEL_ID = "tts_models/multilingual/multi-dataset/your_tts"
+NATIVE_SR = 16000
+SUPPORTED_LANGS = ("en", "fr", "pt-BR")
+_COQUI_LANGS = {
+    "en": "en",
+    "fr": "fr-fr",
+    "pt-BR": "pt-br",
+}
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("YOURTTS_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+class YourTTSBackend(BackendBase):
+    name = "yourtts"
+    display_name = "YourTTS (Coqui VITS, open source)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = SUPPORTED_LANGS
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from TTS.api import TTS
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-yourtts.txt"
+                )
+                log.warning("YourTTS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            device = _device(torch)
+            model_id = os.environ.get("YOURTTS_MODEL", MODEL_ID)
+            log.info("loading %s on %s ...", model_id, device)
+            self._model = TTS(model_id, progress_bar=False).to(device)
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - set()
+        if unknown:
+            raise ValueError(f"YourTTS does not accept extras: {sorted(unknown)}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"YourTTS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("YourTTSBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"yourtts does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        audio = self._model.tts(
+            text=text,
+            speaker_wav=prepared.ref_audio_path,
+            language=_COQUI_LANGS[lang],
+        )
+        if audio is None:
+            raise RuntimeError("YourTTS produced no output")
+        audio_np = _to_numpy(audio)
+        if audio_np.size == 0:
+            raise RuntimeError("YourTTS produced no output")
+        return audio_np, self.sample_rate

--- a/docs/research/tts-backends/yourtts.md
+++ b/docs/research/tts-backends/yourtts.md
@@ -31,10 +31,10 @@ tts.tts_to_file("This is a test sentence.", speaker_wav="reference.wav", languag
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class YourTTSBackend(BackendBase):
-    name = "your_tts"
+    name = "yourtts"
     sample_rate = 16000
-    ref_text_policy = RefTextPolicy.IGNORED
-    supported_langs = ("en", "fr", "pt")
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en", "fr", "pt-BR")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...

--- a/requirements-yourtts.txt
+++ b/requirements-yourtts.txt
@@ -1,0 +1,10 @@
+# Optional YourTTS backend dependencies.
+#
+# Install these only if you plan to use backend=yourtts voice profiles:
+#   pip install -r requirements-yourtts.txt
+#
+# YourTTS uses the same Coqui TTS package family as XTTS v2; this file mirrors
+# requirements-xtts.txt so either optional backend can be installed on its own.
+TTS>=0.22
+torch>=2.1
+torchaudio>=2.1

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -19,7 +19,7 @@ def test_register_all_populates_shipped_backends():
     assert set(backends.names()) == {
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
-        "indextts-2", "neutts-air", "spark-tts", "dia2",
+        "indextts-2", "neutts-air", "spark-tts", "dia2", "yourtts",
     }
 
 
@@ -782,6 +782,92 @@ def test_dia2_synthesize_rejects_unsupported_lang_and_empty_output():
 
     with pytest.raises(ValueError, match="does not support lang='fr'"):
         backend.synthesize("bonjour", prepared, lang="fr")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_yourtts_metadata():
+    from backends.yourtts import YourTTSBackend
+
+    backend = YourTTSBackend()
+
+    assert backend.name == "yourtts"
+    assert backend.display_name == "YourTTS (Coqui VITS, open source)"
+    assert backend.sample_rate == 16000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en", "fr", "pt-BR")
+
+
+def test_yourtts_prepare_voice_allows_optional_ref_text():
+    from backends.yourtts import YourTTSBackend
+
+    backend = YourTTSBackend()
+    prepared = backend.prepare_voice("/tmp/ref.wav", "  reference transcript  ", {})
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference transcript"
+    assert prepared.extras == {}
+
+
+def test_yourtts_rejects_unknown_extras():
+    from backends.yourtts import YourTTSBackend
+
+    backend = YourTTSBackend()
+
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"temperature": 0.8})
+
+
+def test_yourtts_synthesize_calls_coqui_tts_with_language_mapping():
+    import numpy as np
+    from backends.yourtts import YourTTSBackend
+
+    backend = YourTTSBackend()
+    captured_kwargs = {}
+
+    class _YourTTS:
+        def tts(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    backend._model = _YourTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    audio, sr = backend.synthesize("bonjour", prepared, lang="fr")
+
+    assert sr == 16000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured_kwargs == {
+        "text": "bonjour",
+        "speaker_wav": "/tmp/ref.wav",
+        "language": "fr-fr",
+    }
+
+
+def test_yourtts_synthesize_rejects_unsupported_lang_and_empty_output():
+    import numpy as np
+    from backends.yourtts import YourTTSBackend
+
+    backend = YourTTSBackend()
+
+    class _YourTTS:
+        def tts(self, **kwargs):
+            return np.array([], dtype=np.float32)
+
+    backend._model = _YourTTS()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='pt'"):
+        backend.synthesize("ola", prepared, lang="pt")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary

- Add a `yourtts` backend using Coqui `TTS.api.TTS` with lazy optional imports, 16 kHz output, and en/fr/pt-BR language support.
- Register the backend after Dia2 and add mocked protocol/unit coverage for metadata, voice preparation, extras validation, Coqui synthesis kwargs, unsupported language, and empty output handling.
- Add optional dependency notes in `requirements-yourtts.txt` and update README/research docs for the new backend and stale YourTTS metadata.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`