### PR TITLE
feat: add FireRedTTS-2 backend (long conversational + cloning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz. FireRedTTS-2 is available as an optional Apache-2.0 PyTorch backend for long conversational and podcast-style multilingual zero-shot cloning.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -238,6 +238,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `spark-tts` | Apache-2.0 code; CC-BY-NC-SA 4.0 weights | en/zh | 24 kHz | optional |
 | `dia2` | Apache-2.0 | en | 44 kHz | optional |
 | `yourtts` | Open source | en/fr/pt-BR | 16 kHz | optional |
+| `firered-tts-2` | Apache-2.0 | en/zh/ja/ko/fr/de/ru | 24 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -252,7 +253,7 @@ GET  /health
 
        Current backend ids:
        qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
-       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts
+       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts, firered-tts-2
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -42,6 +42,7 @@ def register_all() -> None:
     from .spark_tts import SparkTTSBackend
     from .dia2 import Dia2Backend
     from .yourtts import YourTTSBackend
+    from .firered_tts_2 import FireRedTTS2Backend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -58,6 +59,7 @@ def register_all() -> None:
     register(SparkTTSBackend())
     register(Dia2Backend())
     register(YourTTSBackend())
+    register(FireRedTTS2Backend())
 
 
 def reset_for_tests() -> None:

--- a/backends/firered_tts_2.py
+++ b/backends/firered_tts_2.py
@@ -1,0 +1,193 @@
+"""FireRedTTS-2 backend via FireRedTeam's PyTorch runtime.
+
+FireRedTTS-2 is Apache-2.0 and targets long-form conversational speech. This
+backend uses upstream monologue generation for Afterwords' single-reference
+voice profiles.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.firered_tts_2")
+
+MODEL_ID = "FireRedTeam/FireRedTTS2"
+NATIVE_SR = 24000
+DEFAULT_MODEL_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "backends",
+    "extras",
+    "firered-tts-2",
+    "FireRedTTS2",
+)
+SUPPORTED_LANGS = ("en", "zh", "ja", "ko", "fr", "de", "ru")
+
+_ALLOWED_EXTRAS = {"temperature", "topk", "top_k"}
+
+
+def _model_dir() -> str:
+    return os.environ.get("FIRERED_TTS_2_MODEL_DIR", DEFAULT_MODEL_DIR)
+
+
+def _device(torch) -> str:
+    requested = os.environ.get("FIRERED_TTS_2_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    audio = np.asarray(audio)
+    if np.issubdtype(audio.dtype, np.integer):
+        max_value = float(np.iinfo(audio.dtype).max)
+        audio = audio.astype(np.float32) / max_value
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _coerce_output(output) -> tuple[np.ndarray, int]:
+    if output is None:
+        raise RuntimeError("FireRedTTS-2 produced no output")
+    if isinstance(output, tuple) and len(output) == 2:
+        sample_rate, audio = output
+        return _to_numpy(audio), int(sample_rate)
+    if isinstance(output, Mapping):
+        audio = output.get("audio", output.get("waveform", output.get("wav")))
+        if audio is None:
+            raise RuntimeError("FireRedTTS-2 produced an invalid output")
+        sample_rate = output.get("sample_rate", output.get("sr", NATIVE_SR))
+        return _to_numpy(audio), int(sample_rate)
+    return _to_numpy(output), NATIVE_SR
+
+
+class FireRedTTS2Backend(BackendBase):
+    name = "firered-tts-2"
+    display_name = "FireRedTTS-2 (Apache-2.0)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = SUPPORTED_LANGS
+
+    def __init__(self):
+        super().__init__()
+        self._model = None
+        self._model_dir = _model_dir()
+        self._device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+                from fireredtts2.fireredtts2 import FireRedTTS2
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; "
+                    "install requirements-firered-tts-2.txt"
+                )
+                log.warning("FireRedTTS-2 unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            model_dir = _model_dir()
+            if not os.path.isdir(model_dir):
+                self._unavailable_reason = (
+                    "FireRedTTS-2 model directory not found. Download "
+                    f"{MODEL_ID} to {model_dir!r} or set FIRERED_TTS_2_MODEL_DIR."
+                )
+                log.warning("FireRedTTS-2 unavailable: %s", self._unavailable_reason)
+                return
+
+            device = _device(torch)
+            log.info("loading %s from %s on %s ...", MODEL_ID, model_dir, device)
+            self._model = FireRedTTS2(
+                pretrained_dir=model_dir,
+                gen_type="monologue",
+                device=device,
+            )
+            self._model_dir = model_dir
+            self._device = device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"FireRedTTS-2 does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        if "topk" in extras and "top_k" in extras:
+            raise ValueError("FireRedTTS-2 accepts either topk or top_k, not both")
+        temperature = extras.get("temperature")
+        if temperature is not None and not isinstance(temperature, (int, float)):
+            raise ValueError(f"FireRedTTS-2 temperature must be numeric; got {temperature!r}")
+        if temperature is not None and temperature <= 0:
+            raise ValueError(f"FireRedTTS-2 temperature must be > 0; got {temperature!r}")
+        for key in ("topk", "top_k"):
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"FireRedTTS-2 {key} must be an integer; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"FireRedTTS-2 {key} must be > 0; got {value!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._model is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"FireRedTTS-2 is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("FireRedTTS2Backend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"firered-tts-2 does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        kwargs = {
+            "text": text,
+            "prompt_wav": prepared.ref_audio_path,
+            "prompt_text": prepared.ref_text,
+        }
+        if "temperature" in prepared.extras:
+            kwargs["temperature"] = prepared.extras["temperature"]
+        if "topk" in prepared.extras:
+            kwargs["topk"] = prepared.extras["topk"]
+        if "top_k" in prepared.extras:
+            kwargs["topk"] = prepared.extras["top_k"]
+
+        audio, sample_rate = _coerce_output(self._model.generate_monologue(**kwargs))
+        if not audio.size:
+            raise RuntimeError("FireRedTTS-2 produced no output")
+        return audio.astype(np.float32, copy=False), sample_rate

--- a/docs/research/tts-backends/firered-tts-2.md
+++ b/docs/research/tts-backends/firered-tts-2.md
@@ -1,46 +1,53 @@
 ## FireRedTTS-2
 
-**Repo:** https://github.com/FireRedTeam/FireRedTTS
-**License:** Open Source
-**Size:** 1.5B, 3.0 GB
+**Repo:** https://github.com/FireRedTeam/FireRedTTS2
+**License:** Apache-2.0
+**Size:** 1.5B, ~3.0 GB
 **Sample rate:** 24000
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: Handles long conversational generation well; entirely viable on M5 given enough context buffer.
+**Languages:** en, zh, ja, ko, fr, de, ru
+**Apple Silicon path:** PyTorch+MPS — upstream is CUDA-first, but the backend enables MPS fallback and allows `FIRERED_TTS_2_DEVICE=mps/cpu/cuda`.
 
 ### Install
 ```bash
-git clone https://github.com/FireRedTeam/FireRedTTS.git
-cd FireRedTTS
-pip install -r requirements.txt torch torchaudio
+git clone https://github.com/FireRedTeam/FireRedTTS2.git
+cd FireRedTTS2
+pip install -e .
+pip install -r requirements.txt torch torchaudio torchvision
 ```
 
 ### Model download
 ```bash
-huggingface-cli download FireRedTeam/FireRedTTS-2
+git lfs install
+git clone https://huggingface.co/FireRedTeam/FireRedTTS2 pretrained_models/FireRedTTS2
 ```
 Disk: 3.0 GB
 
 ### Python API for cloning
 ```python
-from fireredtts import FireRedTTS
+from fireredtts2.fireredtts2 import FireRedTTS2
 
-model = FireRedTTS.from_pretrained("FireRedTeam/FireRedTTS-2").to("mps")
-audio = model.synthesize(
+model = FireRedTTS2(
+    pretrained_dir="./pretrained_models/FireRedTTS2",
+    gen_type="monologue",
+    device="mps",
+)
+audio = model.generate_monologue(
     text="This is a test sentence.",
-    ref_audio="reference.wav"
+    prompt_wav="reference.wav",
+    prompt_text=None,
 )
 ```
 
 ### Backend protocol skeleton
 ```python
-# backends/fireredtts_2.py
+# backends/firered_tts_2.py
 from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 
 class FireRedTTS2Backend(BackendBase):
-    name = "fireredtts_2"
+    name = "firered-tts-2"
     sample_rate = 24000
     ref_text_policy = RefTextPolicy.OPTIONAL
-    supported_langs = ("multilingual",)
+    supported_langs = ("en", "zh", "ja", "ko", "fr", "de", "ru")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...

--- a/requirements-firered-tts-2.txt
+++ b/requirements-firered-tts-2.txt
@@ -1,0 +1,24 @@
+# Optional FireRedTTS-2 backend dependencies.
+#
+# Install these only if you plan to use backend=firered-tts-2 voice profiles:
+#   pip install -r requirements-firered-tts-2.txt
+#
+# Download weights separately; the backend does not auto-download them:
+#   git lfs install
+#   git clone https://huggingface.co/FireRedTeam/FireRedTTS2 \
+#     backends/extras/firered-tts-2/FireRedTTS2
+#
+# FireRedTTS-2 code and weights are Apache-2.0. Upstream is CUDA-first; set
+# FIRERED_TTS_2_DEVICE=mps/cpu/cuda to override device selection.
+git+https://github.com/FireRedTeam/FireRedTTS2.git
+torch>=2.7.1
+torchaudio>=2.7.1
+torchvision>=0.22.1
+torchtune
+torchao
+transformers
+einops
+librosa
+optuna
+accelerate
+tensorboard

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -20,6 +20,7 @@ def test_register_all_populates_shipped_backends():
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
         "indextts-2", "neutts-air", "spark-tts", "dia2", "yourtts",
+        "firered-tts-2",
     }
 
 
@@ -868,6 +869,104 @@ def test_yourtts_synthesize_rejects_unsupported_lang_and_empty_output():
 
     with pytest.raises(ValueError, match="does not support lang='pt'"):
         backend.synthesize("ola", prepared, lang="pt")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_firered_tts_2_metadata():
+    from backends.firered_tts_2 import FireRedTTS2Backend
+
+    backend = FireRedTTS2Backend()
+
+    assert backend.name == "firered-tts-2"
+    assert backend.display_name == "FireRedTTS-2 (Apache-2.0)"
+    assert backend.sample_rate == 24000
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en", "zh", "ja", "ko", "fr", "de", "ru")
+
+
+def test_firered_tts_2_prepare_voice_allows_optional_ref_text():
+    from backends.firered_tts_2 import FireRedTTS2Backend
+
+    backend = FireRedTTS2Backend()
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  reference transcript  ",
+        {"temperature": 0.8, "top_k": 30},
+    )
+
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference transcript"
+    assert prepared.extras["temperature"] == 0.8
+    assert prepared.extras["top_k"] == 30
+
+
+def test_firered_tts_2_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.firered_tts_2 import FireRedTTS2Backend
+
+    backend = FireRedTTS2Backend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="top_k must be an integer"):
+        backend.validate_extras({"top_k": 12.5})
+    with pytest.raises(ValueError, match="temperature must be > 0"):
+        backend.validate_extras({"temperature": 0})
+    with pytest.raises(ValueError, match="either topk or top_k"):
+        backend.validate_extras({"topk": 30, "top_k": 30})
+
+
+def test_firered_tts_2_synthesize_calls_monologue_with_prompt_and_sampling():
+    import numpy as np
+    from backends.firered_tts_2 import FireRedTTS2Backend
+
+    backend = FireRedTTS2Backend()
+    captured_kwargs = {}
+
+    class _FireRedTTS2:
+        def generate_monologue(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    backend._model = _FireRedTTS2()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text="reference transcript",
+        extras=_read_only({"temperature": 0.75, "top_k": 25}),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 24000
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured_kwargs == {
+        "text": "hello",
+        "prompt_wav": "/tmp/ref.wav",
+        "prompt_text": "reference transcript",
+        "temperature": 0.75,
+        "topk": 25,
+    }
+
+
+def test_firered_tts_2_synthesize_rejects_unsupported_lang_and_empty_output():
+    import numpy as np
+    from backends.firered_tts_2 import FireRedTTS2Backend
+
+    backend = FireRedTTS2Backend()
+
+    class _FireRedTTS2:
+        def generate_monologue(self, **kwargs):
+            return np.array([], dtype=np.float32)
+
+    backend._model = _FireRedTTS2()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='es'"):
+        backend.synthesize("hola", prepared, lang="es")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary
- add optional FireRedTTS-2 backend with lazy PyTorch imports, local model-dir checks, and monologue voice-cloning synthesis
- register backend id `firered-tts-2` and document optional requirements / README backend table
- refresh stale FireRedTTS-2 research notes and add mocked backend tests

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`