### PR TITLE
feat: add SV2TTS backend (Real-Time Voice Cloning, classic 5s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, Dia2, and YourTTS.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, Dia2, YourTTS, and SV2TTS.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz. FireRedTTS-2 is available as an optional Apache-2.0 PyTorch backend for long conversational and podcast-style multilingual zero-shot cloning.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz. FireRedTTS-2 is available as an optional Apache-2.0 PyTorch backend for long conversational and podcast-style multilingual zero-shot cloning. SV2TTS is available as an optional open-source PyTorch backend using the classic Real-Time Voice Cloning encoder + Tacotron + WaveRNN pipeline for English 5-second cloning.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -239,6 +239,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `dia2` | Apache-2.0 | en | 44 kHz | optional |
 | `yourtts` | Open source | en/fr/pt-BR | 16 kHz | optional |
 | `firered-tts-2` | Apache-2.0 | en/zh/ja/ko/fr/de/ru | 24 kHz | optional |
+| `sv2tts` | Open source | en | 22.05 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -253,7 +254,8 @@ GET  /health
 
        Current backend ids:
        qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
-       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts, firered-tts-2
+       gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts, firered-tts-2,
+       sv2tts
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -43,6 +43,7 @@ def register_all() -> None:
     from .dia2 import Dia2Backend
     from .yourtts import YourTTSBackend
     from .firered_tts_2 import FireRedTTS2Backend
+    from .sv2tts import SV2TTSBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -60,6 +61,7 @@ def register_all() -> None:
     register(Dia2Backend())
     register(YourTTSBackend())
     register(FireRedTTS2Backend())
+    register(SV2TTSBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/sv2tts.py
+++ b/backends/sv2tts.py
@@ -1,0 +1,237 @@
+"""SV2TTS backend via CorentinJ's Real-Time Voice Cloning runtime.
+
+SV2TTS is the classic encoder + Tacotron synthesizer + WaveRNN vocoder
+pipeline. The upstream project can download default models from its own CLI;
+this backend intentionally does not. It only loads locally installed source and
+checkpoint files.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.sv2tts")
+
+MODEL_ID = "CorentinJ/Real-Time-Voice-Cloning"
+NATIVE_SR = 22050
+DEFAULT_BASE_DIR = Path(__file__).resolve().parent / "extras" / "sv2tts"
+DEFAULT_REPO_DIR = DEFAULT_BASE_DIR / "Real-Time-Voice-Cloning"
+DEFAULT_MODEL_DIR = DEFAULT_BASE_DIR / "saved_models" / "default"
+DEFAULT_ENCODER_PATH = DEFAULT_MODEL_DIR / "encoder.pt"
+DEFAULT_SYNTHESIZER_PATH = DEFAULT_MODEL_DIR / "synthesizer.pt"
+DEFAULT_VOCODER_PATH = DEFAULT_MODEL_DIR / "vocoder.pt"
+
+_ALLOWED_EXTRAS = {"vocoder_target", "vocoder_overlap", "vocoder_batched"}
+
+
+def _repo_dir() -> Path:
+    return Path(os.environ.get("SV2TTS_REPO_DIR", DEFAULT_REPO_DIR)).expanduser()
+
+
+def _encoder_path() -> Path:
+    return Path(os.environ.get("SV2TTS_ENCODER_PATH", DEFAULT_ENCODER_PATH)).expanduser()
+
+
+def _synthesizer_path() -> Path:
+    return Path(os.environ.get("SV2TTS_SYNTHESIZER_PATH", DEFAULT_SYNTHESIZER_PATH)).expanduser()
+
+
+def _vocoder_path() -> Path:
+    return Path(os.environ.get("SV2TTS_VOCODER_PATH", DEFAULT_VOCODER_PATH)).expanduser()
+
+
+def _encoder_device(torch) -> str:
+    requested = os.environ.get("SV2TTS_ENCODER_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _add_repo_to_path(repo_dir: Path) -> None:
+    repo = str(repo_dir)
+    if repo_dir.is_dir() and repo not in sys.path:
+        sys.path.insert(0, repo)
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _no_progress(*args) -> None:
+    return None
+
+
+class SV2TTSBackend(BackendBase):
+    name = "sv2tts"
+    display_name = "SV2TTS (Real-Time Voice Cloning, open source)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("en",)
+
+    def __init__(self):
+        super().__init__()
+        self._encoder = None
+        self._synthesizer = None
+        self._vocoder = None
+        self._model = None
+        self._repo_dir = _repo_dir()
+        self._encoder_device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; install requirements-sv2tts.txt"
+                )
+                log.warning("SV2TTS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            repo_dir = _repo_dir()
+            _add_repo_to_path(repo_dir)
+            try:
+                from encoder import inference as encoder
+                from synthesizer.inference import Synthesizer
+                from vocoder import inference as vocoder
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "Real-Time Voice Cloning source is not importable. Clone "
+                    f"{MODEL_ID} to {repo_dir!r} or set SV2TTS_REPO_DIR."
+                )
+                log.warning("SV2TTS unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            encoder_path = _encoder_path()
+            synthesizer_path = _synthesizer_path()
+            vocoder_path = _vocoder_path()
+            missing = [
+                str(path)
+                for path in (encoder_path, synthesizer_path, vocoder_path)
+                if not path.exists()
+            ]
+            if missing:
+                self._unavailable_reason = (
+                    "SV2TTS checkpoint files not found. Provide encoder, synthesizer, "
+                    "and vocoder .pt files under "
+                    f"{DEFAULT_MODEL_DIR!r}, or set SV2TTS_*_PATH. Missing: {missing}"
+                )
+                log.warning("SV2TTS unavailable: %s", self._unavailable_reason)
+                return
+
+            encoder_device = _encoder_device(torch)
+            log.info("loading %s encoder on %s ...", MODEL_ID, encoder_device)
+            encoder.load_model(encoder_path, device=encoder_device)
+            log.info("loading %s synthesizer from %s ...", MODEL_ID, synthesizer_path)
+            synthesizer = Synthesizer(synthesizer_path, verbose=False)
+            synthesizer.load()
+            log.info("loading %s vocoder from %s ...", MODEL_ID, vocoder_path)
+            vocoder.load_model(vocoder_path, verbose=False)
+
+            self._encoder = encoder
+            self._synthesizer = synthesizer
+            self._vocoder = vocoder
+            self._model = (encoder, synthesizer, vocoder)
+            self._repo_dir = repo_dir
+            self._encoder_device = encoder_device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"SV2TTS does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in ("vocoder_target", "vocoder_overlap"):
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"SV2TTS {key} must be an integer; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"SV2TTS {key} must be > 0; got {value!r}")
+        batched = extras.get("vocoder_batched")
+        if batched is not None and not isinstance(batched, bool):
+            raise ValueError(f"SV2TTS vocoder_batched must be boolean; got {batched!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if self._encoder is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"SV2TTS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("SV2TTSBackend.prepare_voice called before load()")
+
+        wav = self._encoder.preprocess_wav(ref_audio_path)
+        speaker_embedding = self._encoder.embed_utterance(wav)
+        prepared_extras = dict(extras)
+        prepared_extras["speaker_embedding"] = np.asarray(speaker_embedding, dtype=np.float32)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(prepared_extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._synthesizer is None or self._vocoder is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"SV2TTS is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("SV2TTSBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"sv2tts does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        speaker_embedding = prepared.extras.get("speaker_embedding")
+        if speaker_embedding is None:
+            raise RuntimeError("SV2TTS prepared voice is missing speaker_embedding")
+
+        specs = self._synthesizer.synthesize_spectrograms(
+            [text],
+            [np.asarray(speaker_embedding, dtype=np.float32)],
+        )
+        if not specs:
+            raise RuntimeError("SV2TTS produced no spectrogram")
+
+        audio = self._vocoder.infer_waveform(
+            specs[0],
+            batched=bool(prepared.extras.get("vocoder_batched", True)),
+            target=int(prepared.extras.get("vocoder_target", 8000)),
+            overlap=int(prepared.extras.get("vocoder_overlap", 800)),
+            progress_callback=_no_progress,
+        )
+        audio_np = _to_numpy(audio)
+        if audio_np.size == 0:
+            raise RuntimeError("SV2TTS produced no output")
+        return audio_np, self.sample_rate

--- a/docs/research/tts-backends/sv2tts.md
+++ b/docs/research/tts-backends/sv2tts.md
@@ -5,35 +5,38 @@
 **Size:** <0.5 GB
 **Sample rate:** 22050
 **Languages:** en-only
-**Apple Silicon path:** PyTorch+MPS — Note: Very old repository (Tacotron-based); some dependencies might need tweaking for modern MPS PyTorch.
+**Apple Silicon path:** PyTorch CPU/MPS hybrid — Note: Very old repository (Tacotron-based). The encoder can be directed to MPS, but the upstream synthesizer and WaveRNN vocoder still choose CUDA-or-CPU internally, so CPU fallback is the reliable default on Apple Silicon.
 
 ### Install
 ```bash
 git clone https://github.com/CorentinJ/Real-Time-Voice-Cloning.git
 cd Real-Time-Voice-Cloning
-pip install -r requirements.txt
+uv sync --extra cpu
 ```
 
 ### Model download
 ```bash
-# Uses a manual download script inside the repository
-python download_models.py
+# Upstream demo code can ensure/download defaults, but the Afterwords backend
+# intentionally does not download. Put local files here or set env overrides:
+mkdir -p backends/extras/sv2tts/saved_models/default
+# encoder.pt, synthesizer.pt, vocoder.pt
 ```
 Disk: 0.5 GB
 
 ### Python API for cloning
 ```python
+from pathlib import Path
 from encoder import inference as encoder
 from synthesizer.inference import Synthesizer
 from vocoder import inference as vocoder
 
-encoder.load_model("encoder/saved_models/pretrained.pt")
-synthesizer = Synthesizer("synthesizer/saved_models/pretrained/pretrained.pt")
-vocoder.load_model("vocoder/saved_models/pretrained/pretrained.pt")
+encoder.load_model(Path("saved_models/default/encoder.pt"))
+synthesizer = Synthesizer(Path("saved_models/default/synthesizer.pt"))
+vocoder.load_model(Path("saved_models/default/vocoder.pt"))
 
 embed = encoder.embed_utterance(encoder.preprocess_wav("reference.wav"))
 specs = synthesizer.synthesize_spectrograms(["This is a test sentence."], [embed])
-audio = vocoder.infer_waveform(specs)
+audio = vocoder.infer_waveform(specs[0])
 ```
 
 ### Backend protocol skeleton
@@ -44,15 +47,16 @@ from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 class SV2TTSBackend(BackendBase):
     name = "sv2tts"
     sample_rate = 22050
-    ref_text_policy = RefTextPolicy.IGNORED
+    ref_text_policy = RefTextPolicy.OPTIONAL
     supported_langs = ("en",)
 
     def load(self): ...
+    def validate_extras(self, extras): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
     def synthesize(self, text, prepared, lang): ...
 ```
 
 ### Notes for afterwords integration
-- This is the classic 3-stage SV2TTS model. Because of its older architecture, `load()` must load three distinct models: Encoder, Synthesizer, and Vocoder. `prepare_voice` should convert the audio path to the unified speaker embedding matrix using the encoder. The crucial point to test is whether `vocoder.infer_waveform` functions correctly natively on MPS; WaveRNN operations can be notoriously slow or mathematically tricky on Apple Silicon, so falling back to CPU explicitly for the vocoder pass might be required for stability.
+- This is the classic 3-stage SV2TTS model. Because of its older architecture, `load()` must load three distinct models: Encoder, Synthesizer, and Vocoder. `prepare_voice` should convert the audio path to a speaker embedding using the encoder. The backend must keep upstream imports lazy and must not call upstream model-download helpers. The crucial runtime risk is WaveRNN speed/stability on Apple Silicon; CPU fallback is expected unless upstream grows a first-class MPS path.
 
 ---

--- a/requirements-sv2tts.txt
+++ b/requirements-sv2tts.txt
@@ -1,0 +1,25 @@
+# Optional SV2TTS / Real-Time Voice Cloning backend dependencies.
+#
+# Install these only if you plan to use backend=sv2tts voice profiles:
+#   pip install -r requirements-sv2tts.txt
+#
+# The upstream project is source-layout oriented and its demo CLI may download
+# default models. This backend does not download anything. Clone source and
+# place checkpoints manually:
+#   git clone https://github.com/CorentinJ/Real-Time-Voice-Cloning.git \
+#     backends/extras/sv2tts/Real-Time-Voice-Cloning
+#   mkdir -p backends/extras/sv2tts/saved_models/default
+#   # place encoder.pt, synthesizer.pt, vocoder.pt in that directory
+#
+# Override paths with SV2TTS_REPO_DIR, SV2TTS_ENCODER_PATH,
+# SV2TTS_SYNTHESIZER_PATH, SV2TTS_VOCODER_PATH, and SV2TTS_ENCODER_DEVICE.
+torch>=2.1
+librosa>=0.10
+soundfile>=0.12
+numpy>=1.24
+scipy>=1.10
+matplotlib>=3.7
+tqdm>=4.66
+inflect>=7
+unidecode>=1.3
+webrtcvad-wheels>=2.0.14

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -20,7 +20,7 @@ def test_register_all_populates_shipped_backends():
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
         "indextts-2", "neutts-air", "spark-tts", "dia2", "yourtts",
-        "firered-tts-2",
+        "firered-tts-2", "sv2tts",
     }
 
 
@@ -967,6 +967,146 @@ def test_firered_tts_2_synthesize_rejects_unsupported_lang_and_empty_output():
 
     with pytest.raises(ValueError, match="does not support lang='es'"):
         backend.synthesize("hola", prepared, lang="es")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_sv2tts_metadata():
+    from backends.sv2tts import SV2TTSBackend
+
+    backend = SV2TTSBackend()
+
+    assert backend.name == "sv2tts"
+    assert backend.display_name == "SV2TTS (Real-Time Voice Cloning, open source)"
+    assert backend.sample_rate == 22050
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("en",)
+
+
+def test_sv2tts_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.sv2tts import SV2TTSBackend
+
+    backend = SV2TTSBackend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="vocoder_target must be an integer"):
+        backend.validate_extras({"vocoder_target": 1200.5})
+    with pytest.raises(ValueError, match="vocoder_overlap must be > 0"):
+        backend.validate_extras({"vocoder_overlap": 0})
+    with pytest.raises(ValueError, match="vocoder_batched must be boolean"):
+        backend.validate_extras({"vocoder_batched": "yes"})
+
+
+def test_sv2tts_prepare_voice_embeds_reference_and_preserves_optional_text():
+    import numpy as np
+    from backends.sv2tts import SV2TTSBackend
+
+    backend = SV2TTSBackend()
+    captured = {}
+
+    class _Encoder:
+        def preprocess_wav(self, path):
+            captured["path"] = path
+            return np.array([0.1, 0.2], dtype=np.float32)
+
+        def embed_utterance(self, wav):
+            captured["wav"] = wav
+            return np.array([0.3, 0.4], dtype=np.float64)
+
+    backend._encoder = _Encoder()
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  reference transcript  ",
+        {"vocoder_target": 4000},
+    )
+
+    assert captured["path"] == "/tmp/ref.wav"
+    assert np.allclose(captured["wav"], [0.1, 0.2])
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference transcript"
+    assert prepared.extras["vocoder_target"] == 4000
+    assert prepared.extras["speaker_embedding"].dtype == np.float32
+    assert np.allclose(prepared.extras["speaker_embedding"], [0.3, 0.4])
+
+
+def test_sv2tts_synthesize_calls_synthesizer_and_vocoder_with_embedding_and_extras():
+    import numpy as np
+    from backends.sv2tts import SV2TTSBackend
+
+    backend = SV2TTSBackend()
+    captured = {}
+
+    class _Synthesizer:
+        def synthesize_spectrograms(self, texts, embeds):
+            captured["texts"] = texts
+            captured["embeds"] = embeds
+            return [np.ones((80, 4), dtype=np.float32)]
+
+    class _Vocoder:
+        def infer_waveform(self, mel, **kwargs):
+            captured["mel"] = mel
+            captured["vocoder_kwargs"] = kwargs
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    backend._synthesizer = _Synthesizer()
+    backend._vocoder = _Vocoder()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({
+            "speaker_embedding": np.array([0.3, 0.4], dtype=np.float64),
+            "vocoder_target": 4000,
+            "vocoder_overlap": 400,
+            "vocoder_batched": False,
+        }),
+    )
+
+    audio, sr = backend.synthesize("hello", prepared, lang="en")
+
+    assert sr == 22050
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured["texts"] == ["hello"]
+    assert captured["embeds"][0].dtype == np.float32
+    assert np.allclose(captured["embeds"][0], [0.3, 0.4])
+    assert captured["mel"].shape == (80, 4)
+    assert captured["vocoder_kwargs"]["batched"] is False
+    assert captured["vocoder_kwargs"]["target"] == 4000
+    assert captured["vocoder_kwargs"]["overlap"] == 400
+    assert callable(captured["vocoder_kwargs"]["progress_callback"])
+
+
+def test_sv2tts_synthesize_rejects_unsupported_lang_missing_embedding_and_empty_output():
+    import numpy as np
+    from backends.sv2tts import SV2TTSBackend
+
+    backend = SV2TTSBackend()
+
+    class _Synthesizer:
+        def synthesize_spectrograms(self, texts, embeds):
+            return [np.ones((80, 4), dtype=np.float32)]
+
+    class _Vocoder:
+        def infer_waveform(self, mel, **kwargs):
+            return np.array([], dtype=np.float32)
+
+    backend._synthesizer = _Synthesizer()
+    backend._vocoder = _Vocoder()
+    prepared_without_embedding = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({"speaker_embedding": np.array([0.3, 0.4], dtype=np.float32)}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='fr'"):
+        backend.synthesize("bonjour", prepared, lang="fr")
+    with pytest.raises(RuntimeError, match="missing speaker_embedding"):
+        backend.synthesize("hello", prepared_without_embedding, lang="en")
     with pytest.raises(RuntimeError, match="produced no output"):
         backend.synthesize("hello", prepared, lang="en")
 


### PR DESCRIPTION
## Summary

- Add an optional `sv2tts` backend for CorentinJ Real-Time Voice Cloning / SV2TTS.
- Register it after FireRedTTS-2 and document installation/checkpoint expectations.
- Add mocked backend tests covering metadata, extras validation, reference embedding preparation, synthesis dispatch, and error handling.

## Notes

The backend keeps upstream imports inside `load()` and does not invoke any upstream download helpers. It expects source/checkpoints to be placed locally under `backends/extras/sv2tts/...` or supplied via `SV2TTS_*` environment variables.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`
- `git diff --check`