### PR TITLE
feat: add MockingBird backend (Chinese-focused SV2TTS extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[Listen to the voice demos →](https://adrianwedd.github.io/afterwords/)** &nbsp; [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/adrianwedd/afterwords/blob/main/colab/afterwords_comparison.ipynb)
 
-Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, Dia2, YourTTS, and SV2TTS.
+Clone any voice from a 15-second YouTube clip and run it locally on your Mac. Use it as a standalone TTS API, or pair it with Claude Code to hear every response spoken aloud. 50+ voices included across MLX backends (Qwen3 0.6B/1.7B, Chatterbox, VoxCPM 1.5, Voxtral) plus optional OpenVoice v2, F5-TTS, CosyVoice2, GPT-SoVITS, XTTS v2, IndexTTS-2, NeuTTS Air, Spark-TTS, Dia2, YourTTS, SV2TTS, and MockingBird.
 
 No cloud API. No subscription. No data leaves your machine. The voice comes from a 15-second audio sample — yours, a friend's, or anyone on YouTube.
 
@@ -220,7 +220,7 @@ The skill handles voice selection, server health checks, synthesis, and playback
 
 ### Voice Cloning (Zero-Shot)
 
-No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz. FireRedTTS-2 is available as an optional Apache-2.0 PyTorch backend for long conversational and podcast-style multilingual zero-shot cloning. SV2TTS is available as an optional open-source PyTorch backend using the classic Real-Time Voice Cloning encoder + Tacotron + WaveRNN pipeline for English 5-second cloning.
+No training or fine-tuning. The default MLX-based backends extract speaker embeddings from 15-second reference clips and generate new speech in that voice: Qwen3-TTS 0.6B & 1.7B (Alibaba, multilingual), Chatterbox fp16 (Resemble AI, multilingual), VoxCPM 1.5 (ModelBest, en/zh), and Voxtral 4B (preset voices). OpenVoice v2 is available as an optional PyTorch/MeloTTS backend for zero-shot multilingual cloning in en/es/fr/zh/ja/ko. F5-TTS is available as an optional PyTorch backend using the flow-matching DiT `F5TTS_v1_Base` model for en/zh; its default pretrained weights are CC-BY-NC 4.0 and are not for commercial use. CosyVoice2-0.5B is available as an optional Apache-2.0 PyTorch backend for multilingual zero-shot cloning. GPT-SoVITS is available as an optional MIT-licensed PyTorch backend for few-shot cloning in en/zh/ja/ko/yue. XTTS v2 is available as an optional Coqui TTS backend for 17-language zero-shot cloning; its CPML weights are non-commercial only. IndexTTS-2 is available as an optional PyTorch backend for expressive en/zh zero-shot cloning with emotion controls; its bilibili model license includes usage restrictions. NeuTTS Air is available as an optional Apache-2.0 CPU-first backend for English zero-shot cloning via Neuphonic's `neutts` package. Spark-TTS is available as an optional LLM+BiCodec PyTorch backend for en/zh zero-shot cloning and code-switching; its published 0.5B weights are CC-BY-NC-SA 4.0 and non-commercial. Dia2 is available as an optional Apache-2.0 PyTorch backend for English dialogue-oriented voice conditioning with `[S1]`/`[S2]` speaker tags and nonverbal cues. YourTTS is available as an optional open-source Coqui VITS backend for lightweight en/fr/pt-BR zero-shot cloning at 16 kHz. FireRedTTS-2 is available as an optional Apache-2.0 PyTorch backend for long conversational and podcast-style multilingual zero-shot cloning. SV2TTS is available as an optional open-source PyTorch backend using the classic Real-Time Voice Cloning encoder + Tacotron + WaveRNN pipeline for English 5-second cloning. MockingBird is available as an optional open-source PyTorch backend using a Chinese-focused SV2TTS-derived encoder + Tacotron + WaveRNN pipeline.
 
 | Backend | License | Languages | Sample rate | Reference text |
 |---------|---------|-----------|-------------|----------------|
@@ -240,6 +240,7 @@ No training or fine-tuning. The default MLX-based backends extract speaker embed
 | `yourtts` | Open source | en/fr/pt-BR | 16 kHz | optional |
 | `firered-tts-2` | Apache-2.0 | en/zh/ja/ko/fr/de/ru | 24 kHz | optional |
 | `sv2tts` | Open source | en | 22.05 kHz | optional |
+| `mockingbird` | Open source | zh/en | 22.05 kHz | optional |
 
 Voice profiles pin to a specific backend via the `backend` JSON field. The shipped flagship voices (picard, galadriel, attenborough) have per-backend variants so you can compare clone fidelity across models — Qwen3 sizes are the most reliable cloners in the current stack; see the [demo site](https://adrianwedd.github.io/afterwords/) for audible comparison.
 
@@ -255,7 +256,7 @@ GET  /health
        Current backend ids:
        qwen3-0.6b, qwen3-1.7b, chatterbox, voxcpm-1.5, voxtral, openvoice-v2, f5-tts, cosyvoice2,
        gpt-sovits, xtts-v2, indextts-2, neutts-air, spark-tts, dia2, yourtts, firered-tts-2,
-       sv2tts
+       sv2tts, mockingbird
 
 GET  /synthesize?text=Hello&voice=galadriel&lang=en
        → audio/wav (16-bit PCM)

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -44,6 +44,7 @@ def register_all() -> None:
     from .yourtts import YourTTSBackend
     from .firered_tts_2 import FireRedTTS2Backend
     from .sv2tts import SV2TTSBackend
+    from .mockingbird import MockingBirdBackend
 
     register(Qwen3Backend(size="0.6B"))
     register(Qwen3Backend(size="1.7B"))
@@ -62,6 +63,7 @@ def register_all() -> None:
     register(YourTTSBackend())
     register(FireRedTTS2Backend())
     register(SV2TTSBackend())
+    register(MockingBirdBackend())
 
 
 def reset_for_tests() -> None:

--- a/backends/mockingbird.py
+++ b/backends/mockingbird.py
@@ -1,0 +1,264 @@
+"""MockingBird backend via babysor's SV2TTS-derived PyTorch runtime.
+
+MockingBird extends the classic encoder + Tacotron synthesizer + WaveRNN
+vocoder architecture with a Chinese-focused training/tooling stack. This
+backend never downloads source or checkpoints; it only loads local files.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+from .base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
+
+log = logging.getLogger("backends.mockingbird")
+
+MODEL_ID = "babysor/MockingBird"
+NATIVE_SR = 22050
+DEFAULT_BASE_DIR = Path(__file__).resolve().parent / "extras" / "mockingbird"
+DEFAULT_REPO_DIR = DEFAULT_BASE_DIR / "MockingBird"
+DEFAULT_MODEL_DIR = DEFAULT_BASE_DIR / "saved_models" / "default"
+DEFAULT_ENCODER_PATH = DEFAULT_MODEL_DIR / "encoder.pt"
+DEFAULT_SYNTHESIZER_PATH = DEFAULT_MODEL_DIR / "synthesizer.pt"
+DEFAULT_VOCODER_PATH = DEFAULT_MODEL_DIR / "vocoder.pt"
+SUPPORTED_LANGS = ("zh", "en")
+
+_ALLOWED_EXTRAS = {"vocoder_target", "vocoder_overlap", "vocoder_batched"}
+_RUNTIME_MODULES = (
+    "encoder",
+    "synthesizer",
+    "vocoder",
+)
+
+
+def _repo_dir() -> Path:
+    return Path(os.environ.get("MOCKINGBIRD_REPO_DIR", DEFAULT_REPO_DIR)).expanduser()
+
+
+def _encoder_path() -> Path:
+    return Path(os.environ.get("MOCKINGBIRD_ENCODER_PATH", DEFAULT_ENCODER_PATH)).expanduser()
+
+
+def _synthesizer_path() -> Path:
+    return Path(os.environ.get("MOCKINGBIRD_SYNTHESIZER_PATH", DEFAULT_SYNTHESIZER_PATH)).expanduser()
+
+
+def _vocoder_path() -> Path:
+    return Path(os.environ.get("MOCKINGBIRD_VOCODER_PATH", DEFAULT_VOCODER_PATH)).expanduser()
+
+
+def _encoder_device(torch) -> str:
+    requested = os.environ.get("MOCKINGBIRD_ENCODER_DEVICE")
+    if requested:
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _add_repo_to_path(repo_dir: Path) -> None:
+    repo = str(repo_dir)
+    if repo_dir.is_dir() and repo not in sys.path:
+        sys.path.insert(0, repo)
+
+
+def _module_path(module) -> Path | None:
+    file = getattr(module, "__file__", None)
+    if not file:
+        return None
+    return Path(file).resolve()
+
+
+def _evict_conflicting_runtime_modules(repo_dir: Path) -> None:
+    """Avoid reusing SV2TTS modules that share MockingBird's top-level names."""
+    resolved_repo = repo_dir.resolve()
+    for name in _RUNTIME_MODULES:
+        module_names = [key for key in sys.modules if key == name or key.startswith(f"{name}.")]
+        for module_name in module_names:
+            module = sys.modules.get(module_name)
+            module_path = _module_path(module) if module is not None else None
+            if module_path is not None and resolved_repo not in module_path.parents:
+                sys.modules.pop(module_name, None)
+
+
+def _to_numpy(audio) -> np.ndarray:
+    if hasattr(audio, "detach"):
+        audio = audio.detach()
+    if hasattr(audio, "cpu"):
+        audio = audio.cpu()
+    if hasattr(audio, "numpy"):
+        audio = audio.numpy()
+    return np.asarray(audio, dtype=np.float32).reshape(-1)
+
+
+def _no_progress(*args) -> None:
+    return None
+
+
+class MockingBirdBackend(BackendBase):
+    name = "mockingbird"
+    display_name = "MockingBird (Chinese-focused SV2TTS, open source)"
+    model_id = MODEL_ID
+    sample_rate = NATIVE_SR
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = SUPPORTED_LANGS
+
+    def __init__(self):
+        super().__init__()
+        self._encoder = None
+        self._synthesizer = None
+        self._vocoder = None
+        self._model = None
+        self._repo_dir = _repo_dir()
+        self._encoder_device = None
+        self._unavailable_reason = None
+
+    def load(self) -> None:
+        def _do():
+            try:
+                os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+                import torch
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "optional dependencies are not installed; install "
+                    "requirements-mockingbird.txt"
+                )
+                log.warning("MockingBird unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            repo_dir = _repo_dir()
+            _add_repo_to_path(repo_dir)
+            _evict_conflicting_runtime_modules(repo_dir)
+            try:
+                from encoder import inference as encoder
+                from synthesizer.inference import Synthesizer
+                from vocoder import inference as vocoder
+            except ImportError as exc:
+                self._unavailable_reason = (
+                    "MockingBird source is not importable. Clone "
+                    f"{MODEL_ID} to {repo_dir!r} or set MOCKINGBIRD_REPO_DIR."
+                )
+                log.warning("MockingBird unavailable: %s (%s)", self._unavailable_reason, exc)
+                return
+
+            encoder_path = _encoder_path()
+            synthesizer_path = _synthesizer_path()
+            vocoder_path = _vocoder_path()
+            missing = [
+                str(path)
+                for path in (encoder_path, synthesizer_path, vocoder_path)
+                if not path.exists()
+            ]
+            if missing:
+                self._unavailable_reason = (
+                    "MockingBird checkpoint files not found. Provide encoder, "
+                    "synthesizer, and vocoder .pt files under "
+                    f"{DEFAULT_MODEL_DIR!r}, or set MOCKINGBIRD_*_PATH. Missing: {missing}"
+                )
+                log.warning("MockingBird unavailable: %s", self._unavailable_reason)
+                return
+
+            encoder_device = _encoder_device(torch)
+            log.info("loading %s encoder on %s ...", MODEL_ID, encoder_device)
+            encoder.load_model(encoder_path, device=encoder_device)
+            log.info("loading %s synthesizer from %s ...", MODEL_ID, synthesizer_path)
+            synthesizer = Synthesizer(synthesizer_path, verbose=False)
+            if hasattr(synthesizer, "load"):
+                synthesizer.load()
+            log.info("loading %s vocoder from %s ...", MODEL_ID, vocoder_path)
+            vocoder.load_model(vocoder_path, verbose=False)
+
+            self._encoder = encoder
+            self._synthesizer = synthesizer
+            self._vocoder = vocoder
+            self._model = (encoder, synthesizer, vocoder)
+            self._repo_dir = repo_dir
+            self._encoder_device = encoder_device
+            self._unavailable_reason = None
+
+        self._ensure_loaded(_do)
+
+    def validate_extras(self, extras: Mapping[str, object]) -> None:
+        unknown = set(extras) - _ALLOWED_EXTRAS
+        if unknown:
+            raise ValueError(
+                f"MockingBird does not accept extras: {sorted(unknown)}; "
+                f"allowed: {sorted(_ALLOWED_EXTRAS)}"
+            )
+        for key in ("vocoder_target", "vocoder_overlap"):
+            value = extras.get(key)
+            if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+                raise ValueError(f"MockingBird {key} must be an integer; got {value!r}")
+            if value is not None and value <= 0:
+                raise ValueError(f"MockingBird {key} must be > 0; got {value!r}")
+        batched = extras.get("vocoder_batched")
+        if batched is not None and not isinstance(batched, bool):
+            raise ValueError(f"MockingBird vocoder_batched must be boolean; got {batched!r}")
+
+    def prepare_voice(
+        self,
+        ref_audio_path: str,
+        ref_text: str | None,
+        extras: Mapping[str, object],
+    ) -> PreparedVoice:
+        self.validate_extras(extras)
+        if self._encoder is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"MockingBird is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("MockingBirdBackend.prepare_voice called before load()")
+
+        wav = self._encoder.preprocess_wav(ref_audio_path)
+        speaker_embedding = self._encoder.embed_utterance(wav)
+        prepared_extras = dict(extras)
+        prepared_extras["speaker_embedding"] = np.asarray(speaker_embedding, dtype=np.float32)
+        ref_text = ref_text.strip() if ref_text and ref_text.strip() else None
+        return PreparedVoice(
+            ref_audio_path=ref_audio_path,
+            ref_text=ref_text,
+            extras=_read_only(prepared_extras),
+        )
+
+    def synthesize(
+        self,
+        text: str,
+        prepared: PreparedVoice,
+        lang: str,
+    ) -> tuple[np.ndarray, int]:
+        if self._synthesizer is None or self._vocoder is None:
+            if self._unavailable_reason:
+                raise RuntimeError(f"MockingBird is unavailable: {self._unavailable_reason}")
+            raise RuntimeError("MockingBirdBackend.synthesize called before load()")
+        if lang not in self.supported_langs:
+            raise ValueError(
+                f"mockingbird does not support lang={lang!r}; supported: {self.supported_langs}"
+            )
+
+        speaker_embedding = prepared.extras.get("speaker_embedding")
+        if speaker_embedding is None:
+            raise RuntimeError("MockingBird prepared voice is missing speaker_embedding")
+
+        specs = self._synthesizer.synthesize_spectrograms(
+            [text],
+            [np.asarray(speaker_embedding, dtype=np.float32)],
+        )
+        if not specs:
+            raise RuntimeError("MockingBird produced no spectrogram")
+
+        audio = self._vocoder.infer_waveform(
+            specs[0],
+            batched=bool(prepared.extras.get("vocoder_batched", True)),
+            target=int(prepared.extras.get("vocoder_target", 8000)),
+            overlap=int(prepared.extras.get("vocoder_overlap", 800)),
+            progress_callback=_no_progress,
+        )
+        audio_np = _to_numpy(audio)
+        if audio_np.size == 0:
+            raise RuntimeError("MockingBird produced no output")
+        return audio_np, self.sample_rate

--- a/docs/research/tts-backends/00-summary.md
+++ b/docs/research/tts-backends/00-summary.md
@@ -25,7 +25,7 @@ NotebookLM deep research over 60 sources from arXiv, HuggingFace, project repos,
 | [OpenVoice v2](openvoice-v2.md) | MIT | — | — | multi | Tone-color + style decoupled |
 | [FireRedTTS-2](firered-tts-2.md) | Open Source | 1.5B | — | multi | Long conversational |
 | [SV2TTS](sv2tts.md) | Open Source | — | — | en | Classic 5-second cloning |
-| [MockingBird](mockingbird.md) | Open Source | — | — | multi | Chinese-focused SV2TTS extension |
+| [MockingBird](mockingbird.md) | Open Source | <0.5 GB | 22k | zh/en | Chinese-focused SV2TTS extension |
 | [GPT-SoVITS](gpt-sovits.md) | Open Source | — | — | multi | High community traction |
 | [SoproTTS](soprotts.md) | Open Source | — | — | multi | — |
 | [NeuTTS Air](neutts-air.md) | Proprietary | 0.75B | 24k | en | On-device CoreML |

--- a/docs/research/tts-backends/mockingbird.md
+++ b/docs/research/tts-backends/mockingbird.md
@@ -4,14 +4,16 @@
 **License:** Open Source
 **Size:** <0.5 GB
 **Sample rate:** 22050
-**Languages:** multilingual
-**Apple Silicon path:** PyTorch+MPS — Note: Same architectural constraints as SV2TTS; focus on Mandarin compatibility.
+**Languages:** zh/en (multilingual toolkit; Chinese strongest)
+**Apple Silicon path:** PyTorch+MPS fallback — same architectural constraints as SV2TTS; focus on Mandarin compatibility.
+**Reference text policy:** OPTIONAL
 
 ### Install
 ```bash
 git clone https://github.com/babysor/MockingBird.git
 cd MockingBird
 pip install -r requirements.txt
+pip install cn2an
 ```
 
 ### Model download
@@ -43,8 +45,8 @@ from backends.base import BackendBase, PreparedVoice, RefTextPolicy, _read_only
 class MockingBirdBackend(BackendBase):
     name = "mockingbird"
     sample_rate = 22050
-    ref_text_policy = RefTextPolicy.IGNORED
-    supported_langs = ("multilingual",)
+    ref_text_policy = RefTextPolicy.OPTIONAL
+    supported_langs = ("zh", "en")
 
     def load(self): ...
     def prepare_voice(self, ref_audio_path, ref_text, extras): ...
@@ -52,6 +54,9 @@ class MockingBirdBackend(BackendBase):
 ```
 
 ### Notes for afterwords integration
-- MockingBird operates on identical logic to SV2TTS but integrates language-specific grapheme-to-phoneme parsing specifically suited to Chinese datasets. The main implementation difference from SV2TTS for your `afterwords` backend is the front-end text normalization. Ensure your text handling in `synthesize` successfully supports the localized tokenizer required by the MockingBird synthesizer, and similarly watch out for WaveRNN generation speeds on MPS.
+- MockingBird operates on the same encoder + Tacotron synthesizer + WaveRNN vocoder shape as SV2TTS, but its tooling and pretrained ecosystem are Chinese-focused.
+- Keep source and checkpoint paths separate from SV2TTS because both projects expose top-level `encoder`, `synthesizer`, and `vocoder` modules.
+- Do not trigger upstream demo downloads from the backend. Require local source under `backends/extras/mockingbird/MockingBird` and local checkpoint files under `backends/extras/mockingbird/saved_models/default`.
+- `cn2an` is useful for Chinese number normalization, but the backend should still delegate text handling to the upstream synthesizer rather than doing ad hoc normalization in Afterwords.
 
 ---

--- a/requirements-mockingbird.txt
+++ b/requirements-mockingbird.txt
@@ -1,0 +1,27 @@
+# Optional MockingBird backend dependencies.
+#
+# Install these only if you plan to use backend=mockingbird voice profiles:
+#   pip install -r requirements-mockingbird.txt
+#
+# The upstream project is source-layout oriented and its demo scripts may
+# download default models. This backend does not download anything. Clone source
+# and place checkpoints manually:
+#   git clone https://github.com/babysor/MockingBird.git \
+#     backends/extras/mockingbird/MockingBird
+#   mkdir -p backends/extras/mockingbird/saved_models/default
+#   # place encoder.pt, synthesizer.pt, vocoder.pt in that directory
+#
+# Override paths with MOCKINGBIRD_REPO_DIR, MOCKINGBIRD_ENCODER_PATH,
+# MOCKINGBIRD_SYNTHESIZER_PATH, MOCKINGBIRD_VOCODER_PATH, and
+# MOCKINGBIRD_ENCODER_DEVICE.
+torch>=2.1
+librosa>=0.10
+soundfile>=0.12
+numpy>=1.24
+scipy>=1.10
+matplotlib>=3.7
+tqdm>=4.66
+inflect>=7
+unidecode>=1.3
+webrtcvad-wheels>=2.0.14
+cn2an>=0.5

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -20,7 +20,7 @@ def test_register_all_populates_shipped_backends():
         "qwen3-0.6b", "qwen3-1.7b", "chatterbox", "voxcpm-1.5", "voxtral",
         "openvoice-v2", "f5-tts", "cosyvoice2", "gpt-sovits", "xtts-v2",
         "indextts-2", "neutts-air", "spark-tts", "dia2", "yourtts",
-        "firered-tts-2", "sv2tts",
+        "firered-tts-2", "sv2tts", "mockingbird",
     }
 
 
@@ -1105,6 +1105,146 @@ def test_sv2tts_synthesize_rejects_unsupported_lang_missing_embedding_and_empty_
 
     with pytest.raises(ValueError, match="does not support lang='fr'"):
         backend.synthesize("bonjour", prepared, lang="fr")
+    with pytest.raises(RuntimeError, match="missing speaker_embedding"):
+        backend.synthesize("hello", prepared_without_embedding, lang="en")
+    with pytest.raises(RuntimeError, match="produced no output"):
+        backend.synthesize("hello", prepared, lang="en")
+
+
+def test_mockingbird_metadata():
+    from backends.mockingbird import MockingBirdBackend
+
+    backend = MockingBirdBackend()
+
+    assert backend.name == "mockingbird"
+    assert backend.display_name == "MockingBird (Chinese-focused SV2TTS, open source)"
+    assert backend.sample_rate == 22050
+    assert backend.ref_text_policy is RefTextPolicy.OPTIONAL
+    assert backend.supported_langs == ("zh", "en")
+
+
+def test_mockingbird_validate_extras_rejects_unknown_and_invalid_values():
+    from backends.mockingbird import MockingBirdBackend
+
+    backend = MockingBirdBackend()
+    with pytest.raises(ValueError, match="does not accept extras"):
+        backend.validate_extras({"speed": 1.1})
+    with pytest.raises(ValueError, match="vocoder_target must be an integer"):
+        backend.validate_extras({"vocoder_target": 1200.5})
+    with pytest.raises(ValueError, match="vocoder_overlap must be > 0"):
+        backend.validate_extras({"vocoder_overlap": 0})
+    with pytest.raises(ValueError, match="vocoder_batched must be boolean"):
+        backend.validate_extras({"vocoder_batched": "yes"})
+
+
+def test_mockingbird_prepare_voice_embeds_reference_and_preserves_optional_text():
+    import numpy as np
+    from backends.mockingbird import MockingBirdBackend
+
+    backend = MockingBirdBackend()
+    captured = {}
+
+    class _Encoder:
+        def preprocess_wav(self, path):
+            captured["path"] = path
+            return np.array([0.1, 0.2], dtype=np.float32)
+
+        def embed_utterance(self, wav):
+            captured["wav"] = wav
+            return np.array([0.3, 0.4], dtype=np.float64)
+
+    backend._encoder = _Encoder()
+    prepared = backend.prepare_voice(
+        "/tmp/ref.wav",
+        "  reference transcript  ",
+        {"vocoder_target": 4000},
+    )
+
+    assert captured["path"] == "/tmp/ref.wav"
+    assert np.allclose(captured["wav"], [0.1, 0.2])
+    assert prepared.ref_audio_path == "/tmp/ref.wav"
+    assert prepared.ref_text == "reference transcript"
+    assert prepared.extras["vocoder_target"] == 4000
+    assert prepared.extras["speaker_embedding"].dtype == np.float32
+    assert np.allclose(prepared.extras["speaker_embedding"], [0.3, 0.4])
+
+
+def test_mockingbird_synthesize_calls_synthesizer_and_vocoder_with_embedding_and_extras():
+    import numpy as np
+    from backends.mockingbird import MockingBirdBackend
+
+    backend = MockingBirdBackend()
+    captured = {}
+
+    class _Synthesizer:
+        def synthesize_spectrograms(self, texts, embeds):
+            captured["texts"] = texts
+            captured["embeds"] = embeds
+            return [np.ones((80, 4), dtype=np.float32)]
+
+    class _Vocoder:
+        def infer_waveform(self, mel, **kwargs):
+            captured["mel"] = mel
+            captured["vocoder_kwargs"] = kwargs
+            return np.array([[0.1, -0.2]], dtype=np.float64)
+
+    backend._synthesizer = _Synthesizer()
+    backend._vocoder = _Vocoder()
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({
+            "speaker_embedding": np.array([0.3, 0.4], dtype=np.float64),
+            "vocoder_target": 4000,
+            "vocoder_overlap": 400,
+            "vocoder_batched": False,
+        }),
+    )
+
+    audio, sr = backend.synthesize("ni hao", prepared, lang="zh")
+
+    assert sr == 22050
+    assert audio.dtype == np.float32
+    assert np.allclose(audio, [0.1, -0.2])
+    assert captured["texts"] == ["ni hao"]
+    assert captured["embeds"][0].dtype == np.float32
+    assert np.allclose(captured["embeds"][0], [0.3, 0.4])
+    assert captured["mel"].shape == (80, 4)
+    assert captured["vocoder_kwargs"]["batched"] is False
+    assert captured["vocoder_kwargs"]["target"] == 4000
+    assert captured["vocoder_kwargs"]["overlap"] == 400
+    assert callable(captured["vocoder_kwargs"]["progress_callback"])
+
+
+def test_mockingbird_synthesize_rejects_unsupported_lang_missing_embedding_and_empty_output():
+    import numpy as np
+    from backends.mockingbird import MockingBirdBackend
+
+    backend = MockingBirdBackend()
+
+    class _Synthesizer:
+        def synthesize_spectrograms(self, texts, embeds):
+            return [np.ones((80, 4), dtype=np.float32)]
+
+    class _Vocoder:
+        def infer_waveform(self, mel, **kwargs):
+            return np.array([], dtype=np.float32)
+
+    backend._synthesizer = _Synthesizer()
+    backend._vocoder = _Vocoder()
+    prepared_without_embedding = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({}),
+    )
+    prepared = PreparedVoice(
+        ref_audio_path="/tmp/ref.wav",
+        ref_text=None,
+        extras=_read_only({"speaker_embedding": np.array([0.3, 0.4], dtype=np.float32)}),
+    )
+
+    with pytest.raises(ValueError, match="does not support lang='ja'"):
+        backend.synthesize("konnichiwa", prepared, lang="ja")
     with pytest.raises(RuntimeError, match="missing speaker_embedding"):
         backend.synthesize("hello", prepared_without_embedding, lang="en")
     with pytest.raises(RuntimeError, match="produced no output"):


### PR DESCRIPTION
## Summary

- Add a MockingBird backend using the SV2TTS-style encoder, synthesizer, and vocoder pipeline with lazy runtime imports and local-only checkpoint loading.
- Register `mockingbird` after `sv2tts` and add mocked backend protocol tests for metadata, extras validation, voice preparation, synthesis dispatch, and error handling.
- Add optional dependency guidance plus README and research documentation updates for the backend table and install path.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_backends.py -v`