### PR TITLE
fix: codex watcher fails loudly + diagnose flag (partial #39)

### DIFF
--- a/.claude/hooks/codex-tts-watch.sh
+++ b/.claude/hooks/codex-tts-watch.sh
@@ -4,21 +4,85 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="${SCRIPT_DIR}/codex-tts-hook.sh"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CODEX_WATCH_LOG="${CODEX_WATCH_LOG:-/tmp/codex-tts-watch.log}"
+DIAGNOSE=0
+
+if [ "${1:-}" = "--diagnose" ]; then
+    DIAGNOSE=1
+    shift
+fi
+
 THREAD_ID="${1:-${CODEX_THREAD_ID:-}}"
 PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
 
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$CODEX_WATCH_LOG"
+}
+
+describe_event() {
+    python3 -c '
+import json
+import sys
+
+try:
+    event = json.loads(sys.stdin.read())
+except json.JSONDecodeError:
+    print("invalid-json")
+    raise SystemExit(0)
+
+payload = event.get("payload") or {}
+parts = ["type={}".format(event.get("type", ""))]
+for key in ("type", "role", "phase"):
+    value = payload.get(key)
+    if value:
+        parts.append("payload_{}={}".format(key, value))
+print(" ".join(parts))
+'
+}
+
+detect_sample_event() {
+    printf '%s\n' '{"type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"diagnostic sample"}]}}' |
+        python3 "${REPO_DIR}/codex_session_hook.py" 2>/dev/null
+}
+
 if [ -z "$THREAD_ID" ]; then
-    echo "CODEX_THREAD_ID is not set. Run this inside Codex CLI or pass a thread id." >&2
-    exit 1
+    log "CODEX_THREAD_ID is not set. Run this inside Codex CLI or pass a thread id."
+    if [ "$DIAGNOSE" -eq 1 ]; then
+        echo "CODEX_THREAD_ID is not set. Run this inside Codex CLI or pass a thread id."
+        echo "Log: ${CODEX_WATCH_LOG}"
+    fi
+    exit 2
 fi
 
 SESSION_FILE=$(rg -l "\"id\":\"${THREAD_ID}\"" "$HOME/.codex/sessions" -g '*.jsonl' 2>/dev/null | head -1)
-if [ -z "$SESSION_FILE" ]; then
-    echo "Could not find Codex session file for thread ${THREAD_ID}." >&2
-    exit 1
+
+if [ "$DIAGNOSE" -eq 1 ]; then
+    echo "Codex watcher diagnose"
+    echo "Thread: ${THREAD_ID}"
+    echo "Sessions root: ${HOME}/.codex/sessions"
+    echo "Session file: ${SESSION_FILE:-not found}"
+    echo "Project dir: ${PROJECT_DIR}"
+    echo "Hook: ${HOOK}"
+    echo "Log: ${CODEX_WATCH_LOG}"
+    if [ "$(detect_sample_event)" = "diagnostic sample" ]; then
+        echo "Sample event detection: ok"
+    else
+        echo "Sample event detection: failed"
+        exit 4
+    fi
+    [ -n "$SESSION_FILE" ] || exit 3
+    exit 0
 fi
 
-echo "Watching ${SESSION_FILE}" >&2
+if [ -z "$SESSION_FILE" ]; then
+    log "no session file found for thread ${THREAD_ID}"
+    exit 3
+fi
+
+log "watching ${SESSION_FILE} for thread ${THREAD_ID}"
 tail -n 0 -F "$SESSION_FILE" | while IFS= read -r line; do
+    summary=$(printf '%s\n' "$line" | describe_event)
+    log "event ${summary}"
     printf '%s\n' "$line" | PROJECT_DIR="$PROJECT_DIR" bash "$HOOK"
 done

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ afterwords codex-hook stop
 
 The watcher needs `ripgrep` (`brew install ripgrep`) to locate the session file. Setup auto-detects Codex and prints these commands when it finishes; you don't have to memorize them.
 
+For watcher debugging, run `afterwords codex-hook status`; it reports stale pid files and shows the tail of `/tmp/codex-tts-watch.log` when the watcher is not running. `afterwords codex-hook start --diagnose` prints the thread id, session file it would watch, hook path, and sample event detection without starting the daemon. The most common startup failures are `$CODEX_THREAD_ID` not being exported, or Codex not having created the first session event yet, so no `~/.codex/sessions/.../rollout-*.jsonl` file matches the thread id.
+
 Trade-offs vs Claude Code: this depends on Codex's local session file format and on `$CODEX_THREAD_ID` being exported, both undocumented contracts that may shift between Codex versions. For non-interactive Codex (`codex exec`), prefer wrapping with `--output-last-message <FILE>` and feeding the file to `/synthesize` directly — cleaner and version-stable.
 
 ## With Gemini CLI

--- a/afterwords.sh
+++ b/afterwords.sh
@@ -393,10 +393,27 @@ cmd_codex_hook() {
     local subcommand="${1:-status}"
     local watcher="${REPO_DIR}/${CODEX_WATCH_SCRIPT_REL}"
     local pid=""
+    local diagnose=""
+
+    codex_watch_log_tail() {
+        if [ -s "$CODEX_WATCH_LOG" ]; then
+            info "Recent watcher log:"
+            tail -20 "$CODEX_WATCH_LOG" | sed 's/^/    /'
+        else
+            warn "Watcher log is empty: ${CODEX_WATCH_LOG}"
+        fi
+    }
 
     case "$subcommand" in
         start)
+            diagnose="${2:-}"
             [ -f "$watcher" ] || fail "Watcher script not found at ${watcher}"
+            if [ "$diagnose" = "--diagnose" ]; then
+                CODEX_THREAD_ID="${CODEX_THREAD_ID:-}" PROJECT_DIR="$REPO_DIR" CODEX_WATCH_LOG="$CODEX_WATCH_LOG" \
+                    bash "$watcher" --diagnose
+                return $?
+            fi
+            [ -z "$diagnose" ] || fail "Unknown codex-hook start option: ${diagnose}. Use --diagnose."
             [ -n "${CODEX_THREAD_ID:-}" ] || fail "CODEX_THREAD_ID is not set. Run inside Codex CLI or export it first."
 
             if [ -f "$CODEX_WATCH_PID" ]; then
@@ -410,9 +427,17 @@ cmd_codex_hook() {
                 rm -f "$CODEX_WATCH_PID"
             fi
 
-            nohup env CODEX_THREAD_ID="$CODEX_THREAD_ID" PROJECT_DIR="$REPO_DIR" \
-                bash "$watcher" >"$CODEX_WATCH_LOG" 2>&1 &
+            : > "$CODEX_WATCH_LOG"
+            nohup env CODEX_THREAD_ID="$CODEX_THREAD_ID" PROJECT_DIR="$REPO_DIR" CODEX_WATCH_LOG="$CODEX_WATCH_LOG" \
+                bash "$watcher" >>"$CODEX_WATCH_LOG" 2>&1 &
             pid=$!
+            sleep 0.5
+            if ! kill -0 "$pid" 2>/dev/null; then
+                wait "$pid" 2>/dev/null
+                rm -f "$CODEX_WATCH_PID"
+                codex_watch_log_tail
+                fail "Codex watcher failed to start"
+            fi
             echo "$pid" > "$CODEX_WATCH_PID"
             ok "Codex watcher started (PID ${pid})"
             info "Thread: ${DIM}${CODEX_THREAD_ID}${NC}"
@@ -444,9 +469,11 @@ cmd_codex_hook() {
                     ok "Codex watcher running (PID ${pid})"
                 else
                     warn "Codex watcher pid file exists but process is not running"
+                    codex_watch_log_tail
                 fi
             else
                 warn "Codex watcher is not running"
+                codex_watch_log_tail
             fi
             info "Log: ${DIM}${CODEX_WATCH_LOG}${NC}"
             ;;
@@ -544,7 +571,7 @@ cmd_help() {
     echo -e "  ${BOLD}Options:${NC}"
     echo -e "    ${DIM}voices --demo${NC}    Play a sample of each voice"
     echo -e "    ${DIM}clone URL NAME [START] [--yes]${NC}"
-    echo -e "    ${DIM}codex-hook start${NC}"
+    echo -e "    ${DIM}codex-hook start [--diagnose]${NC}"
     echo
     echo -e "  ${BOLD}Examples:${NC}"
     echo -e "    ${DIM}afterwords start${NC}"


### PR DESCRIPTION
## Summary

- make the Codex watcher fail loudly when `CODEX_THREAD_ID` is missing or no matching session JSONL exists
- add watcher diagnostics and per-event watch-log summaries for debugging session-file changes
- make `afterwords codex-hook start` detect immediate watcher death, avoid stale pid files, and show recent watcher logs
- document the `status` and `start --diagnose` debugging flow

## Root Cause

The watcher already exited when it could not resolve a thread id to a session file, but `afterwords codex-hook start` wrote the pid file and reported success before checking whether the child survived. That left stale pid files and misleading status output.

## Validation

- `bash -n .claude/hooks/codex-tts-watch.sh`
- `bash -n afterwords.sh`
- unset thread smoke test: watcher exits 2 and logs the missing `CODEX_THREAD_ID`
- missing session smoke test: watcher exits 3 and logs `no session file found for thread ...`
- real session smoke test: `afterwords codex-hook start/status/stop` resolves a real session file and logs the watched path
- stale pid smoke test: `afterwords codex-hook status` shows recent watcher log tail
- `PYTHONPATH=. .venv/bin/pytest`
