### PR TITLE
test: skip mlx_audio test on Linux CI

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -657,6 +657,7 @@ def test_chatterbox_prepare_voice_preserves_extras():
 
 def test_chatterbox_synthesize_forwards_lang_and_defaults(monkeypatch, tmp_path):
     """synthesize should forward lang_code, cfg_weight, and exaggeration to generate_audio."""
+    pytest.importorskip("mlx_audio")
     from backends.chatterbox import ChatterboxBackend, _DEFAULT_CFG_WEIGHT, _DEFAULT_EXAGGERATION
     from backends.base import PreparedVoice, _read_only
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ to exercise the full synthesis response path.
 import json
 import os
 
+import pytest
 import server
 
 


### PR DESCRIPTION
`mlx_audio` is Apple Silicon only. On Linux CI runners `No module named 'mlx_audio'` causes one test to error instead of skip.

Adds `pytest.importorskip("mlx_audio")` at the top of `test_chatterbox_synthesize_forwards_lang_and_defaults` so it skips cleanly on unsupported platforms.