### PR TITLE
fix(cli): filter lsof to LISTEN sockets for server_pid()

### DIFF
--- a/afterwords.sh
+++ b/afterwords.sh
@@ -69,7 +69,7 @@ plist_exists() {
 
 # Find PID listening on the TTS port (works whether launchd or manual)
 server_pid() {
-    lsof -ti :"$PORT" 2>/dev/null | head -1
+    lsof -ti :"$PORT" -sTCP:LISTEN 2>/dev/null | head -1
 }
 
 # Get PID from launchd (available before port binding)


### PR DESCRIPTION
## Summary

- `server_pid()` used `lsof -ti :PORT | head -1`, which returns any process with a socket open to that port — including the macOS menu-bar app's health-poll client connections
- The app PID was returned instead of the server PID, causing `afterwords status` to display the wrong process
- Fix: add `-sTCP:LISTEN` to restrict to the actual listening process

## Test plan

- [ ] `afterwords start` then `afterwords status` — PID shown matches the Python `server.py` process, not the menu-bar app
- [ ] Works with both launchd-managed and manually-started server
- [ ] `bash -n afterwords.sh` passes