### PR TITLE
fix: BASHPID in play-lock subshell; direct JSON reads in Codex worker

### DIFF
--- a/.claude/hooks/codex-tts-worker.sh
+++ b/.claude/hooks/codex-tts-worker.sh
@@ -70,16 +70,10 @@ while true; do
     done < <(ls -1t "$QUEUEDIR"/*.json 2>/dev/null | tail -r 2>/dev/null || ls -1 "$QUEUEDIR"/*.json 2>/dev/null | sort)
     [ -z "$ITEM" ] && break
 
-    # Parse JSON item. Use shlex.quote to emit a safe eval block — handles
-    # newlines and special chars in text without shell delimiter tricks.
-    ITEM_EVAL=$(python3 -c "
-import json, sys, shlex
-d = json.load(open(sys.argv[1]))
-print('PROJECT_DIR=' + shlex.quote(d.get('project_dir','')))
-print('AGENT=' + shlex.quote(d.get('agent','')))
-print('TEXT=' + shlex.quote(d.get('text','')))
-" "$ITEM" 2>/dev/null) || { rm -f "$ITEM"; continue; }
-    eval "$ITEM_EVAL"
+    # Parse JSON item fields directly — avoids eval on queue content.
+    PROJECT_DIR=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('project_dir',''))" "$ITEM" 2>/dev/null) || { rm -f "$ITEM"; continue; }
+    AGENT=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('agent',''))" "$ITEM" 2>/dev/null) || true
+    TEXT=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('text',''))" "$ITEM" 2>/dev/null) || { rm -f "$ITEM"; continue; }
     rm -f "$ITEM"
     [ -z "${TEXT:-}" ] && continue
 

--- a/scripts/afterwords-tts-command.sh
+++ b/scripts/afterwords-tts-command.sh
@@ -139,10 +139,10 @@ with open(sys.argv[1], 'wb') as f:
             fi
             sleep 0.3
         done
-        echo $BASHPID > "$PLAY_PID"
+        bash -c 'echo $PPID' > "$PLAY_PID"
 
         # Synthesize
-        TMP_WAV="/tmp/afterwords-cmd-$BASHPID.wav"
+        TMP_WAV=$(mktemp /tmp/afterwords-cmd-XXXXXX.wav)
         HTTP_CODE=$(curl -s -w "%{http_code}" -o "$TMP_WAV" "$URL" 2>/dev/null || echo "000")
 
         if [ "$HTTP_CODE" = "200" ] && [ -s "$TMP_WAV" ]; then

--- a/scripts/afterwords-tts-command.sh
+++ b/scripts/afterwords-tts-command.sh
@@ -139,10 +139,10 @@ with open(sys.argv[1], 'wb') as f:
             fi
             sleep 0.3
         done
-        echo $$ > "$PLAY_PID"
+        echo $BASHPID > "$PLAY_PID"
 
         # Synthesize
-        TMP_WAV="/tmp/afterwords-cmd-$$.wav"
+        TMP_WAV="/tmp/afterwords-cmd-$BASHPID.wav"
         HTTP_CODE=$(curl -s -w "%{http_code}" -o "$TMP_WAV" "$URL" 2>/dev/null || echo "000")
 
         if [ "$HTTP_CODE" = "200" ] && [ -s "$TMP_WAV" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -314,7 +314,7 @@ else
 fi
 echo
 
-if $HAS_CLAUDE || command -v gemini &>/dev/null || command -v agy &>/dev/null; then
+if ! $SERVER_ONLY && { $HAS_CLAUDE || command -v gemini &>/dev/null || command -v agy &>/dev/null; }; then
 next_step "Claude & CLI hooks"
 
 HOOKS_DIR="$HOME/.claude/hooks"
@@ -779,7 +779,7 @@ if command -v codex &>/dev/null; then
 fi
 
 # ── Gemini CLI discovery (manual config; gemini hooks migrate is buggy) ────
-if command -v gemini &>/dev/null; then
+if ! $SERVER_ONLY && command -v gemini &>/dev/null; then
     GEMINI_HOOK_DEST="$HOME/.claude/hooks/gemini-tts-hook.sh"
     GEMINI_SETTINGS="$HOME/.gemini/settings.json"
     echo
@@ -818,7 +818,7 @@ GEMINI_SNIPPET
 fi
 
 # ── Antigravity CLI discovery (agy) ──────────────────────────────────────
-if command -v agy &>/dev/null; then
+if ! $SERVER_ONLY && command -v agy &>/dev/null; then
     AGY_HOOK_DEST="$HOME/.claude/hooks/agy-tts-hook.sh"
     AGY_PYTHON_DEST="$HOME/.claude/hooks/agy-session-hook.py"
     AGY_CONFIG_DIR="$HOME/.gemini/config"


### PR DESCRIPTION
## Summary

Three fixes from QA review of #74:

### 1. Stale PID in play-lock subshell (`afterwords-tts-command.sh`)

The background synthesis subshell wrote \`\$\$\` (parent PID) to the play-lock PID file. Once the parent exits, \`kill -0\` sees a dead PID, clears the lock, and allows a second agent to start audio before synthesis finishes.

Fix: \`bash -c 'echo \$PPID' > "\$PLAY_PID"\` — spawns a direct child whose \`\$PPID\` is the running subshell. Portable on macOS bash 3.2 (no \`\$BASHPID\`). Also switches \`TMP_WAV\` to \`mktemp\`.

### 2. \`eval\` on queue content (`codex-tts-worker.sh`)

The Codex worker used \`eval\` on a \`shlex.quote\`'d string from a world-writable queue directory. Replaced with direct \`python3\` field extraction per variable — identical behaviour, no \`eval\`.

### 3. \`setup.sh --server-only\` installs hooks when Gemini/AGy present

Three blocks ran on CLI presence alone, ignoring \`--server-only\`:
- Shared hooks block (line 317): \`if \$HAS_CLAUDE || command -v gemini || command -v agy\`
- Gemini block (line 782): \`if command -v gemini\`
- AGy block (line 821): \`if command -v agy\`

All three now gated on \`! \$SERVER_ONLY &&\`.

## Test plan

- [x] \`bash -n setup.sh scripts/afterwords-tts-command.sh .claude/hooks/codex-tts-worker.sh\` — pass
- [x] \`bash -c 'echo \$PPID'\` confirmed on macOS bash 3.2.57 — writes actual subshell PID, matches \`\$!\`, stays alive during worker body
- [x] \`mktemp /tmp/afterwords-cmd-XXXXXX.wav\` — valid on macOS
- [x] 505 tests pass in venv
- [x] CI green