### PR TITLE
Security fixes from 2026-06-10 audit (server — Part B)

### DIFF
--- a/.claude/hooks/codex-tts-worker.sh
+++ b/.claude/hooks/codex-tts-worker.sh
@@ -34,10 +34,14 @@ acquire_play_lock() {
 release_play_lock() { rm -f "$PLAY_PID"; rm -rf "$PLAY_LOCK"; }
 
 mkdir -p "$ARCHIVE_DIR"
+if [ -L "$QUEUEDIR" ]; then
+  echo "afterwords: $QUEUEDIR is a symlink — refusing to use it" >&2
+  exit 1
+fi
 mkdir -p "$QUEUEDIR"
 chmod 700 "$QUEUEDIR" 2>/dev/null || true
-if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
-  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+if [ ! -d "$QUEUEDIR" ] || [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is not a directory we own — refusing to use it" >&2
   exit 1
 fi
 

--- a/.claude/hooks/codex-tts-worker.sh
+++ b/.claude/hooks/codex-tts-worker.sh
@@ -33,7 +33,13 @@ acquire_play_lock() {
 }
 release_play_lock() { rm -f "$PLAY_PID"; rm -rf "$PLAY_LOCK"; }
 
-mkdir -p "$ARCHIVE_DIR" "$QUEUEDIR"
+mkdir -p "$ARCHIVE_DIR"
+mkdir -p "$QUEUEDIR"
+chmod 700 "$QUEUEDIR" 2>/dev/null || true
+if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+  exit 1
+fi
 
 if ! mkdir "$LOCKDIR" 2>/dev/null; then
     if [ -f "$PIDFILE" ]; then

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule: { interval: weekly }
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly }

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ voices/*.wav.bak
 # Tool caches
 .wrangler/
 .playwright-mcp/
+
+# Local scratch/QA artefacts (audit: untracked but unignored = git add -A risk)
+/cache/
+/afterwords-redesign/
+/*.diff

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Email adrianwedd@gmail.com with subject "SECURITY: afterwords".
+You'll get an acknowledgement within 72 hours. Please don't open public
+issues for security reports.
+
+## Threat model (short version)
+
+The server is designed for localhost-only use on a single-user Mac. The
+clone/reload/delete endpoints require an explicit --allow-clone opt-in and
+are forced onto 127.0.0.1. Non-loopback binds require --bind-public and
+are at your own risk. The /tmp queue/lock convention assumes a
+single-user machine.
+
+## Supported versions
+
+The latest tagged release.

--- a/scripts/internal/fb-reindex.sh
+++ b/scripts/internal/fb-reindex.sh
@@ -35,8 +35,10 @@ GRN="\033[0;32m"; YLW="\033[0;33m"; RED="\033[0;31m"; DIM="\033[2m"; NC="\033[0m
 # the Graph API. Otherwise, fall back to printing the manual Debugger URLs.
 TOKEN=""
 if [ -n "${FB_APP_ID:-}" ] && [ -n "${FB_APP_SECRET:-}" ]; then
-    TOKEN_URL="https://graph.facebook.com/oauth/access_token?client_id=${FB_APP_ID}&client_secret=${FB_APP_SECRET}&grant_type=client_credentials"
-    TOKEN=$(curl -sS "$TOKEN_URL" | python3 -c 'import sys,json
+    TOKEN=$(curl -sS -X POST "https://graph.facebook.com/oauth/access_token" \
+        --data-urlencode "client_id=${FB_APP_ID}" \
+        --data-urlencode "client_secret=${FB_APP_SECRET}" \
+        --data-urlencode "grant_type=client_credentials" | python3 -c 'import sys,json
 try: print(json.load(sys.stdin).get("access_token",""))
 except: pass' 2>/dev/null)
     if [ -z "$TOKEN" ]; then

--- a/server.py
+++ b/server.py
@@ -104,6 +104,22 @@ async def _validate_host(request, call_next):
     return await call_next(request)
 
 
+@app.middleware("http")
+async def _limit_clone_body(request, call_next):
+    # Reject oversized /clone uploads by Content-Length BEFORE multipart parsing
+    # spools the body to a temp file (audit follow-up: the in-handler read() cap
+    # bounds RAM but the parser had already spooled to disk). A lying/absent
+    # Content-Length still falls through to the in-handler read(MAX+1) cap.
+    if request.url.path == "/clone" and request.method == "POST":
+        cl = request.headers.get("content-length", "")
+        if cl.isdigit() and int(cl) > MAX_CLONE_UPLOAD_BYTES:
+            return JSONResponse(
+                {"error": f"audio exceeds {MAX_CLONE_UPLOAD_BYTES // (1024*1024)}MB limit"},
+                status_code=413,
+            )
+    return await call_next(request)
+
+
 _VOICES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "voices")
 
 # Voice registry: name → (ref_audio_path, ref_text)

--- a/server.py
+++ b/server.py
@@ -210,6 +210,10 @@ def _run_in_ml_thread(fn, *args, **kwargs):
     return _ml_executor.submit(fn, *args, **kwargs).result()
 _clone_enabled = False
 
+# /clone uploads are buffered in RAM for denoising; cap them. 25 MB is ~4 min
+# of 16-bit 48 kHz mono — far beyond the 60 s the cloning path needs.
+MAX_CLONE_UPLOAD_BYTES = 25 * 1024 * 1024
+
 def _register_voice(
     name: str,
     backend_name: str,
@@ -542,7 +546,12 @@ async def clone_voice_endpoint(
             status_code=400,
         )
 
-    audio_bytes = await audio.read()
+    audio_bytes = await audio.read(MAX_CLONE_UPLOAD_BYTES + 1)
+    if len(audio_bytes) > MAX_CLONE_UPLOAD_BYTES:
+        return JSONResponse(
+            {"error": f"audio exceeds {MAX_CLONE_UPLOAD_BYTES // (1024*1024)}MB limit"},
+            status_code=413,
+        )
     if len(audio_bytes) < 1000:
         return JSONResponse({"error": "audio too short"}, status_code=400)
 

--- a/server.py
+++ b/server.py
@@ -96,6 +96,14 @@ async def lifespan(app):
 
 app = FastAPI(title="Afterwords TTS", lifespan=lifespan)
 
+
+@app.middleware("http")
+async def _validate_host(request, call_next):
+    if _enforce_host_check and not _host_allowed(request.headers.get("host", "")):
+        return JSONResponse({"error": "invalid host header"}, status_code=403)
+    return await call_next(request)
+
+
 _VOICES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "voices")
 
 # Voice registry: name → (ref_audio_path, ref_text)
@@ -213,6 +221,21 @@ _clone_enabled = False
 # /clone uploads are buffered in RAM for denoising; cap them. 25 MB is ~4 min
 # of 16-bit 48 kHz mono — far beyond the 60 s the cloning path needs.
 MAX_CLONE_UPLOAD_BYTES = 25 * 1024 * 1024
+
+# Host-header allowlist (audit M3): blocks DNS-rebinding and cross-origin
+# abuse of the GPU. Enabled in main() for loopback binds; stays False under
+# TestClient (which sends Host: testserver) and for --bind-public deployments.
+_enforce_host_check = False
+_ALLOWED_HOSTNAMES = {"localhost", "127.0.0.1", "[::1]"}
+
+
+def _host_allowed(host_header: str) -> bool:
+    host = host_header.strip().lower()
+    if host.startswith("["):                      # [::1] or [::1]:7860
+        hostname = host.split("]")[0] + "]"
+    else:
+        hostname = host.rsplit(":", 1)[0] if ":" in host else host
+    return hostname in _ALLOWED_HOSTNAMES
 
 def _register_voice(
     name: str,
@@ -858,6 +881,27 @@ def reload_voices(prune: bool = False):
     return {"status": "ok", "reloaded": reloaded, "removed": sorted(removed), "errors": []}
 
 
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def _resolve_bind_host(host: str, *, allow_clone: bool, bind_public: bool) -> str:
+    """Decide the actual bind address (audit L2).
+
+    --allow-clone always forces loopback (clone endpoints must never be
+    LAN-reachable). Otherwise a non-loopback host requires the explicit
+    --bind-public opt-in.
+    """
+    if allow_clone and host not in _LOOPBACK_HOSTS:
+        log.info("--allow-clone: binding to 127.0.0.1 for security")
+        return "127.0.0.1"
+    if host not in _LOOPBACK_HOSTS and not bind_public:
+        raise SystemExit(
+            f"refusing to bind {host}: non-loopback binds expose the GPU to the "
+            "network. Re-run with --bind-public if this is intentional."
+        )
+    return host
+
+
 def main():
     parser = argparse.ArgumentParser(description="Afterwords TTS server (MLX)")
     parser.add_argument("--port", type=int, default=7860)
@@ -874,14 +918,20 @@ def main():
         action="store_true",
         help="Also register qwen3-1.7b (default: 0.6b only)",
     )
+    parser.add_argument(
+        "--bind-public",
+        action="store_true",
+        help="Allow binding a non-loopback address (exposes synthesis to the network)",
+    )
     args = parser.parse_args()
 
-    global DEFAULT_VOICE, _clone_enabled, _ml_executor
+    global DEFAULT_VOICE, _clone_enabled, _ml_executor, _enforce_host_check
     if args.allow_clone:
         _clone_enabled = True
-        if args.host == "0.0.0.0":
-            args.host = "127.0.0.1"
-            log.info("--allow-clone: binding to 127.0.0.1 for security")
+    args.host = _resolve_bind_host(
+        args.host, allow_clone=args.allow_clone, bind_public=args.bind_public
+    )
+    _enforce_host_check = args.host in ("127.0.0.1", "localhost", "::1")
 
     # Spin up the dedicated MLX thread BEFORE any backend loading so that all Metal
     # stream IDs (0, 1, 2, …) are created in the same thread that will later run synthesis.

--- a/setup.sh
+++ b/setup.sh
@@ -366,6 +366,11 @@ case "$AGENT" in
 esac
 
 mkdir -p "$QUEUEDIR"
+chmod 700 "$QUEUEDIR" 2>/dev/null || true
+if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+  exit 1
+fi
 ITEM="${QUEUEDIR}/$(date +%s)-${RANDOM}.json"
 ITEM_TMP="${ITEM}.tmp"
 python3 -c "
@@ -434,6 +439,11 @@ echo $$ > "$PIDFILE"
 trap 'rm -f "$PIDFILE"; rm -rf "$LOCKDIR"' EXIT
 
 mkdir -p "$QUEUEDIR"
+chmod 700 "$QUEUEDIR" 2>/dev/null || true
+if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+  exit 1
+fi
 
 while true; do
     # Prune excess items (keep newest MAX_QUEUE).

--- a/setup.sh
+++ b/setup.sh
@@ -365,10 +365,14 @@ case "$AGENT" in
     Explore|Plan|general-purpose) exit 0 ;;
 esac
 
+if [ -L "$QUEUEDIR" ]; then
+  echo "afterwords: $QUEUEDIR is a symlink — refusing to use it" >&2
+  exit 1
+fi
 mkdir -p "$QUEUEDIR"
 chmod 700 "$QUEUEDIR" 2>/dev/null || true
-if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
-  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+if [ ! -d "$QUEUEDIR" ] || [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is not a directory we own — refusing to use it" >&2
   exit 1
 fi
 ITEM="${QUEUEDIR}/$(date +%s)-${RANDOM}.json"
@@ -438,10 +442,14 @@ fi
 echo $$ > "$PIDFILE"
 trap 'rm -f "$PIDFILE"; rm -rf "$LOCKDIR"' EXIT
 
+if [ -L "$QUEUEDIR" ]; then
+  echo "afterwords: $QUEUEDIR is a symlink — refusing to use it" >&2
+  exit 1
+fi
 mkdir -p "$QUEUEDIR"
 chmod 700 "$QUEUEDIR" 2>/dev/null || true
-if [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
-  echo "afterwords: $QUEUEDIR is owned by another user — refusing to use it" >&2
+if [ ! -d "$QUEUEDIR" ] || [ "$(stat -f%u "$QUEUEDIR" 2>/dev/null)" != "$(id -u)" ]; then
+  echo "afterwords: $QUEUEDIR is not a directory we own — refusing to use it" >&2
   exit 1
 fi
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,6 +166,22 @@ def test_clone_rejects_oversized_upload(client, monkeypatch):
     assert "exceeds" in resp.json()["error"]
 
 
+def test_clone_oversized_rejected_before_routing(client, monkeypatch):
+    """Content-Length middleware 413s an oversized /clone before the route runs.
+
+    Clone is DISABLED here: a 413 (not the disabled-path response) proves the
+    body cap fires pre-parser, before multipart spools to disk."""
+    monkeypatch.setattr(server, "_clone_enabled", False)
+    monkeypatch.setattr(server, "MAX_CLONE_UPLOAD_BYTES", 10_000)
+    payload = b"\x00" * 10_001
+    resp = client.post(
+        "/clone",
+        files={"audio": ("big.wav", payload, "audio/wav")},
+        data={"session_id": "pre-route"},
+    )
+    assert resp.status_code == 413
+
+
 # --- POST /synthesize tests ---
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -152,6 +152,20 @@ def test_clone_too_short(client):
     server._clone_enabled = False
 
 
+def test_clone_rejects_oversized_upload(client, monkeypatch):
+    """Uploads beyond MAX_CLONE_UPLOAD_BYTES get 413 before any processing."""
+    monkeypatch.setattr(server, "_clone_enabled", True)
+    monkeypatch.setattr(server, "MAX_CLONE_UPLOAD_BYTES", 10_000)
+    payload = b"\x00" * 10_001
+    resp = client.post(
+        "/clone",
+        files={"audio": ("big.wav", payload, "audio/wav")},
+        data={"session_id": "size-test"},
+    )
+    assert resp.status_code == 413
+    assert "exceeds" in resp.json()["error"]
+
+
 # --- POST /synthesize tests ---
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1009,3 +1009,34 @@ def test_concurrent_synthesize_no_deadlock(client, sample_voice):
     assert all(s == 200 for s in results), f"expected all 200, got {results}"
 
 
+# --- Host-header validation (audit M3) ---
+
+
+def test_host_header_validation_rejects_foreign_host(client, monkeypatch):
+    monkeypatch.setattr(server, "_enforce_host_check", True)
+    resp = client.get("/health", headers={"Host": "evil.example.com"})
+    assert resp.status_code == 403
+
+
+def test_host_header_validation_allows_localhost(client, monkeypatch):
+    monkeypatch.setattr(server, "_enforce_host_check", True)
+    resp = client.get("/health", headers={"Host": "localhost:7860"})
+    assert resp.status_code == 200
+
+
+# --- Bind-host resolution (audit L2) ---
+
+
+def test_resolve_bind_host_refuses_public_without_flag():
+    with pytest.raises(SystemExit):
+        server._resolve_bind_host("0.0.0.0", allow_clone=False, bind_public=False)
+
+
+def test_resolve_bind_host_allows_public_with_flag():
+    assert server._resolve_bind_host("0.0.0.0", allow_clone=False, bind_public=True) == "0.0.0.0"
+
+
+def test_resolve_bind_host_forces_loopback_with_clone():
+    assert server._resolve_bind_host("0.0.0.0", allow_clone=True, bind_public=True) == "127.0.0.1"
+
+


### PR DESCRIPTION
Server-side findings from the 2026-06-10 three-repo security audit. Each commit is independent and leaves the suite green (468 tests).

## Changes
- **B1 — `/clone` upload cap (M1):** 25 MB cap, read `MAX+1` bytes and return 413 before any processing. Previously buffered an unbounded upload in RAM.
- **B2 — Host-header allowlist (M3):** `_validate_host` middleware rejects foreign Host headers (DNS-rebinding / cross-origin GPU abuse). Enabled only for loopback binds; off under TestClient and `--bind-public`.
- **B3 — `--bind-public` gate (L2):** non-loopback binds now require an explicit `--bind-public` opt-in; `--allow-clone` still force-pins 127.0.0.1. Decision logic extracted into the pure, unit-tested `_resolve_bind_host`.
- **B4 — queue-dir hardening (M2, scoped):** `chmod 700` + same-owner check on `/tmp/claude-tts-queue` and `/tmp/codex-tts-queue-*` (in setup.sh hook heredocs and the codex worker). Full `$TMPDIR` migration remains out of scope.
- **B5 — housekeeping:** .gitignore gaps (`/cache/`, `/afterwords-redesign/`, `/*.diff`), removed `pr82.diff` scratch artifact, moved fb-reindex FB credentials into the POST body (off the URL / out of `ps`), added SECURITY.md and Dependabot (pip + actions).

## Out of scope (per plan header)
Full `$TMPDIR` queue/lock migration, the worker's `shlex.quote`d eval, symlink-following PID/log writes — all ride the single-user `/tmp` convention and defer together.

## Tests
- New: oversized-upload 413, host-header reject/allow, `_resolve_bind_host` x3.
- `pytest -q` → **468 passed**.