### PR TITLE
Sprint 7: STRATEGY.md doctrine, hermes dedup fix, issue-sweep chores (#101-#105)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ __pycache__/
 *.DS_Store
 !voices/*.wav
 
-# Afterwords TTS voice override
+# Afterwords TTS voice override — the tracked repo copy ships default
+# agent-to-voice mappings; this entry documents that LOCAL edits are personal
+# preference and are never committed (gitignore does not silence tracked files).
 .afterwords
 
 # Private voices — available locally on the dev machine and loaded by the
@@ -16,6 +18,8 @@ voices/muse*
 voices/vixen*
 
 # QA artefacts
+# Root-level peer-agent QA reports stay local (evidence, not shipped).
+/hermes_qa_*.md
 qa-run.txt
 docs/*-audit.json
 *-output.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ The server (server.py) and voice cloning (clone-voice.sh) are fully independent 
 
 Each hook falls back to `~/.afterwords` (global) before using the server's default voice.
 
+The repo's own `.afterwords` is deliberately both git-tracked (it ships the default agent→voice mapping) and listed in `.gitignore` (so the entry documents intent, though gitignore does not silence tracked files). Local edits to it are personal preference: never commit `.afterwords` changes unless a task explicitly says so.
+
 ## Backends
 
 Registry at `backends/__init__.py`; one Python file per backend implementing the `Backend` protocol (`load / validate_extras / prepare_voice / synthesize`).
@@ -143,3 +145,5 @@ CLI: `afterwords reload` curls the endpoint and pretty-prints the response.
 - `setup.sh` conditionally installs hooks into `~/.claude/` (only when Claude Code is present) and a launchd plist (always)
 - `afterwords.sh` is a pure-bash CLI wrapper (no venv needed) symlinked to `/usr/local/bin/afterwords` by setup.sh — handles start/stop/restart/status/logs/voices/clone/uninstall
 - Shell scripts use macOS-specific tools throughout (afplay, mkdir-based locking, launchd)
+
+Read STRATEGY.md before any task. It overrides your judgment. Conflicts with reality are escalations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ The server (server.py) and voice cloning (clone-voice.sh) are fully independent 
 
 Each hook falls back to `~/.afterwords` (global) before using the server's default voice.
 
+The repo's own `.afterwords` is deliberately both git-tracked (it ships the default agent→voice mapping) and listed in `.gitignore` (so the entry documents intent, though gitignore does not silence tracked files). Local edits to it are personal preference: never commit `.afterwords` changes unless a task explicitly says so.
+
 ## Backends
 
 The `backends/` package exposes a `Backend` Protocol (in `backends/base.py`) and a registry (`backends/__init__.py`). Each backend is a single Python file implementing `load / validate_extras / prepare_voice / synthesize`. Registered shipped backends:
@@ -152,3 +154,5 @@ CLI: `afterwords reload` curls the endpoint and pretty-prints the response.
 - `setup.sh` conditionally installs hooks into `~/.claude/` (only when Claude Code is present) and a launchd plist (always)
 - `afterwords.sh` is a pure-bash CLI wrapper (no venv needed) symlinked to `/usr/local/bin/afterwords` by setup.sh — handles start/stop/restart/status/logs/voices/clone/uninstall
 - Shell scripts use macOS-specific tools throughout (afplay, mkdir-based locking, launchd)
+
+Read STRATEGY.md before any task. It overrides your judgment. Conflicts with reality are escalations.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,69 @@
+# STRATEGY.md — Afterwords
+
+This file overrides executor judgment. Conflict between this file, code, docs, git history, live state, or other agent guidance is DRIFT: report it and stop before relying on the disputed claim. It is never permission to guess. Known conflicts recorded below as documented-stale are exceptions: do not stop on those; any new, broader, or unexplained conflict is drift. Every substantive claim is labeled OBSERVED (explicit in code/docs/history/live state) or INFERRED (probable, evidence stated). UNKNOWN items do not appear here.
+
+## 1. INTENT
+
+Afterwords is a local voice-cloning TTS server for Apple Silicon Macs whose agent integrations (Claude Code, Codex, AGy, Gemini CLI, Cursor, Hermes) speak assistant responses aloud. "Done" for most work = `pytest` green, CI green (tests + OG-metadata guard + Pages asset check), CHANGELOG entry, PR merged to main. It is deliberately NOT a cloud service (that is the separate `~/repos/afterwords-cloud` repo — never edit it from a task scoped here), not cross-platform, and not a general TTS library: macOS-only tools (afplay, launchd, mkdir-locks) are intentional (OBSERVED, CLAUDE.md).
+
+Source-of-truth precedence: code + tests > CLAUDE.md/AGENTS.md > README/docs site > memory/session notes. `docs/` is the **published GitHub Pages site** — committed source-of-truth AND externally visible on every push to main (OBSERVED: CI verifies Pages assets; commit 9832d8e fixed its og:description under a CI guard).
+
+Time-sensitive baselines (re-measure, don't quote): latest release v1.0.6, tagged 2026-06-15; shipped voice gallery 97 families / 193 profiles as of 2026-06-15, derived from `git ls-files voices/*.json` — NOT from on-disk counts (OBSERVED: 308 files on disk vs 294 tracked; untracked + gitignored private voices inflate disk counts, and a prior session shipped a wrong count from `ls`). Recheck trigger: any task touching voice counts, README stats, or `docs/` metadata must recount from `git ls-files` first.
+
+## 2. INVARIANTS
+
+- **Never `git add -A` / `git add .`** Stage named paths only. The working tree deliberately carries untracked scratch, and `.gitignore` itself warns "untracked but unignored = git add -A risk" (OBSERVED).
+- **Never commit, revert, stash, or "clean up" pre-existing dirty files.** As of 2026-07-03 the tree deliberately carries a modified `.afterwords` (local voice preferences — never commit) and local QA artifacts (e.g. `hermes_qa_*.md`, gitignored). The "helpful" pre-commit tidy-up destroys in-progress work. Leave dirty files alone unless the task names them.
+- **Never commit `voices/muse*` or `voices/vixen*`.** Gitignored personal voices that live only on this machine (OBSERVED, .gitignore). `.afterwords` references `vixen` — that file is tracked-despite-gitignore-entry; do not commit local voice-assignment edits to it unless the task says so.
+- **Never delete or rewrite tracked `voices/*.json` / `voices/*-ref.wav`** outside an explicit voice-removal task: they ship with releases and back the public demo site (OBSERVED, CLAUDE.md Key Constraints). Voice removals historically go through a release + count-sync sweep (v1.0.3 pattern).
+- **Any new `afplay` call site must guard the mute flag** (`[ -f /tmp/afterwords-muted ] || afplay …`) or be added to `tests/test_mute_guard.py` EXEMPT with a written rationale. The test auto-discovers all afplay sites; the tempting shortcut is adding playback "just for this script" — CI fails on it (OBSERVED, commit cc16e25 closed fail-open gaps).
+- **Play-lock convention:** PID file at `/tmp/afterwords-play.pid`, NOT inside the lock dir; empty-PID stale detection needs the 50ms recheck (OBSERVED, CLAUDE.md). Don't "simplify" by moving the PID file.
+- **All MLX/Metal ops run on the dedicated ML executor thread**; synthesis serialized via `_synth_lock`. Do not add threading, and do not unpin `mlx-audio` (<0.4.1) to "update deps" — a threading incident forced the executor design (OBSERVED design in server.py/CLAUDE.md; pin rationale INFERRED from session memory).
+- **Do not loosen server security gates:** `--allow-clone` gating on POST endpoints, Host-header allowlist, `--bind-public` gate, 25MB `/clone` cap, queue-dir chmod-700/ownership checks (OBSERVED, commits 981c1fd/108bd37/f1548ef/e625062, audit-driven). The tempting shortcut is relaxing a gate to make a test or demo pass.
+- **Editing any voice-count-bearing text** (README, `docs/index.html`, og:description, CHANGELOG) requires the counts to agree; CI runs `scripts/internal/check-og-metadata.py` and fails on drift (OBSERVED).
+- **Do not modify doctrine** (this file, CLAUDE.md, AGENTS.md, skill/SKILL.md) unless the current task names the file. CLAUDE.md and AGENTS.md are parallel near-duplicates (Claude Code vs Codex audiences); an authorized edit to one usually needs the same edit in the other or they drift (OBSERVED duplication).
+- **Do not act on the hermes 2026-06-21 audit's hygiene claims without re-verifying.** It claimed `.DS_Store` and `.claude/scheduled_tasks.lock` were git-tracked; `git ls-files` disproved both on 2026-07-03 (documented-stale evidence — issue #106 closed as invalid). Untracked lint on disk (`.DS_Store`, `default.profraw`, `__pycache__`) is already gitignored; cleaning it mid-task is scope creep.
+
+## 3. DECISIONS & GRAVEYARD
+
+- **Qwen3-TTS (0.6B default, 1.7B opt-in) is the only endorsed cloning path.** 15 other registered backends are experimental. Decided by listen-tests 2026-05-16 (OBSERVED, CLAUDE.md). Revisit trigger: a new listen-test round, not a benchmark or hunch.
+- **Chatterbox and VoxCPM backends removed entirely** (commit f03e826): failed listen-test; VoxCPM 500'd under launchd (OBSERVED). Do not re-add.
+- **inspector-morse and francis-urquhart voices removed in v1.0.3; ronan deduplicated to mckenna** (OBSERVED, memory + CHANGELOG). Do not resurrect from git history.
+- **`/reload` is add-only by default; pruning is opt-in (`?prune=true`) and scoped to file-originated gallery voices** (OBSERVED, CLAUDE.md). Do not "improve" reload to auto-remove missing voices.
+- **Reference-clip splicing procedure for contaminated sources** is codified in CLAUDE.md (spectral mid/high heuristic, per-chunk denoise, fades, gaps). Follow it; don't invent an alternative pipeline.
+- **A prior Stripe/CF-token-in-.env security finding was explicitly DISMISSED by the owner 2026-06-15** (local-only, never committed). Do not re-flag it (OBSERVED, session memory — documented-stale-adjacent: this is a standing owner decision, not drift).
+- **QA convention:** high-blast-radius changes get review-only peer-agent QA rounds via `codex exec -s read-only`, `hermes -z`, `agy -p` (OBSERVED pattern across sprints 3–6). GitHub issues are the parking lot for deferred findings (OBSERVED, issues #79–#94 workflow).
+
+## 4. FAILURE MODES
+
+- **Shortcut:** count voices with `ls voices/`. **Tell:** number ≠ og:description/README, or CI OG guard fails. **Correction:** count `git ls-files 'voices/*.json'`; families vs profiles are different numbers.
+- **Shortcut:** run the full backend/fidelity test "for completeness." **Tell:** `pytest -m integration tests/test_fidelity.py` loads ~10 GB Metal models and requires the live server stopped. **Correction:** default `pytest` only (no GPU, server may stay up); the fidelity test self-skips when the server is running — that skip is a feature, not a failure.
+- **Shortcut:** restart/stop the launchd server to "get a clean state." **Tell:** `afterwords status` showed it healthy before you touched it. **Correction:** the server is the owner's live, in-use TTS; don't stop/restart it unless the task requires it, and restart it after if you did.
+- **Shortcut:** `rm -rf /tmp/afterwords-play.lock` whenever a lock exists. **Tell:** audio is currently playing. **Correction:** only clear locks that are actually stale (PID dead), per CLAUDE.md.
+- **Shortcut:** treat `pytest` pass as release-done. **Tell:** CI also runs the OG-metadata guard and Pages asset checks that local pytest habits skip. **Correction:** run `python scripts/internal/check-og-metadata.py` too when docs/voices changed.
+- **Shortcut:** summarize or tidy `docs/superpowers/*`, `transcripts/`, or QA reports. **Tell:** file is dated/handover/QA-named. **Correction:** evidence — append-only history; never rewrite.
+- **False-success trap:** older session notes claiming "Sprint 6 CLI unstarted" were WRONG (it shipped in v1.0.5). Trust code + git over narrative notes; verify claims from history before acting on them (OBSERVED, memory corrected 2026-06-15).
+
+## 5. ESCALATION TRIGGERS
+
+Stop before the gated action; continue safe preparatory work (diagnosis, draft patches, branch-ready diffs, dry-runs) and deliver it. Always escalate: drift between sources of truth; destructive/irreversible ops (deleting voices, force-push, history rewrite, `rm` outside scratch/tmp); scope creep beyond the named task; stale time-sensitive facts (voice counts, version numbers, deployment state).
+
+Side-effect classification for this repo:
+- **Allowed without asking:** reading anything; `pytest` (default suite); static checks; local `curl localhost:7860/health` and GET `/synthesize` reads; building patches on a branch; `git log/diff/status`.
+- **Escalate first:** push/merge to main (publishes `docs/` to GitHub Pages — externally visible); tagging/releasing; `afterwords stop/restart` or killing the launchd service; running `setup.sh` (writes `~/.claude/`, `/usr/local/bin` symlink, launchd plist — system mutation); `clone-voice.sh` (external YouTube fetch + big downloads); POST `/clone`, `/reload?prune=true`, `DELETE /session/*` against the live server; editing `~/.claude/hooks/*`, `~/.gemini/*`, `~/.cursor/*` (live hook config of other tools); modifying doctrine or evidence files; anything touching `afterwords-cloud` or Cloudflare/Stripe tooling.
+- **Forbidden:** committing gitignored private voices; deleting evidence files; publishing or exfiltrating voice reference audio outside the repo's existing channels; clearing an active (non-stale) play lock.
+
+GitHub issue filing is conventional here for non-sensitive deferred findings; search for duplicates first. A task is human-blocked only when no safe preparatory work remains — a blocked push/release/deploy alone is not "blocked."
+
+## 6. VERIFICATION
+
+Run in order; report actual output:
+1. `pytest --tb=short -q` — expect all pass/skip, 0 failures (suite ~520 tests as of 2026-06-15; re-measure).
+2. `python scripts/internal/check-og-metadata.py` — expect exit 0 (only needed when docs/voices/counts changed).
+3. Pages asset check (when `docs/` changed): `test -s docs/index.html && test -s docs/404.html && test -s docs/favicons/og-local.png` — expect success.
+4. Live-server checks (read-only): `afterwords status`; `curl localhost:7860/health` — expect HTTP 200 JSON with `loaded_backends`. Only if the server was already running; do not start it to verify.
+5. Fidelity (only when a task explicitly targets cloning quality, and with owner-approved server stop): the CLAUDE.md `pytest -m integration tests/test_fidelity.py` sequence.
+
+Verification never grants permission: if a check needs a push, release, deploy, server restart, or live mutation, report the blocked step instead. Read before write; after any authorized live write (e.g. `/reload`), read back (`/health`, voice list) and report.
+
+If `pytest` dies with `bad interpreter`, the venv broke via a Homebrew Python bump; the fix is `bash setup.sh --server-only` — but that is a system-mutating command: escalate unless the task authorizes it.

--- a/docs/superpowers/plans/2026-06-04-sprint5.md
+++ b/docs/superpowers/plans/2026-06-04-sprint5.md
@@ -1,0 +1,106 @@
+# Sprint 5 Plan — v1.0.4
+**Date:** 2026-06-04  
+**Status:** Planned
+
+## Goal
+
+Ship a clean v1.0.4 release that resolves the housekeeping backlog from Sprints 3–4 (untracked voices, requirements bloat, launchd UX gap) and creates the GitHub releases that were skipped for v1.0.3 and v1.0.4.
+
+---
+
+## Part A — Release v1.0.3 + v1.0.4 on GitHub (#79 adjacent)
+
+v1.0.3 was tagged and pushed on 2026-05-30 but the GitHub release was deliberately skipped. Current main (lean defaults + docs expansion) is unreleased.
+
+**Steps:**
+1. Write CHANGELOG entry for v1.0.4 (lean default install, docs expansion, 5 QA fixes)
+2. Tag `v1.0.4` from current main
+3. `gh release create v1.0.3 --latest false --notes "$(awk '/\[1\.0\.3\]/{...}' CHANGELOG.md)"`
+4. `gh release create v1.0.4 --latest --notes "$(awk '/\[1\.0\.4\]/{...}' CHANGELOG.md)"`
+
+**Acceptance:** Both releases visible on GitHub Releases page; v1.0.4 is marked Latest.
+
+---
+
+## Part B — Resolve untracked voice profiles (issue #81)
+
+10 voices (`muse1–4`, `vixen`, their qwen3-06b variants) exist on disk but aren't git-tracked. Sprint 3 described them as "private" — verify with user whether they should be:
+
+- **Gitignored** (preferred if truly private) — add `voices/muse*.json voices/vixen*.json` to `.gitignore`
+- **Tracked** — add to git, bump og:description to 200
+
+**User decision required before executing.**
+
+---
+
+## Part C — Split requirements-clone.txt (issue #80)
+
+Move cloning-only deps out of `requirements.txt`:
+
+```
+requirements.txt        → server + synthesis only (remove faster-whisper, noisereduce)
+requirements-clone.txt  → faster-whisper, noisereduce (cloning only)
+requirements-dev.txt    → unchanged (includes both via -r flags)
+```
+
+`setup.sh` changes:
+- `--server-only` installs only `requirements.txt`
+- Full setup installs both
+- `clone-voice.sh` checks for `faster-whisper` and prompts `pip install -r requirements-clone.txt` if missing
+
+**Acceptance:** `pytest` green; `setup.sh --server-only` completes without installing faster-whisper.
+
+---
+
+## Part D — launchd `--with-1.7b` mechanism (issue #79)
+
+Design: config file approach (`~/.afterwords-config` or `~/.config/afterwords/config`).
+
+```bash
+# afterwords configure --with-1.7b   → writes WITH_17B=true, regenerates plist, reloads
+# afterwords configure --no-1.7b     → removes flag, regenerates plist, reloads
+# afterwords status                  → shows "1.7B: enabled" line
+```
+
+`setup.sh` reads the config when generating the plist so `bash setup.sh` picks it up.
+
+**Acceptance:**
+- `afterwords configure --with-1.7b && afterwords restart` loads both backends
+- `afterwords status` reflects the setting
+- Documented in README
+
+---
+
+## Part E — afterwords-app Stage 2 GUI smoke test (deferred from Sprint 3)
+
+Manual QA checklist (human needed at the machine):
+- [ ] Voice-list window renders all 190 gallery voices
+- [ ] Port-override field changes probed port
+- [ ] Auto-start toggle persists across quit/relaunch
+- [ ] Menubar icon shows ● (running) / ○ (stopped) state correctly
+
+App lives at `/Users/adrian/repos/afterwords-app`. Run `afterwords-app.app` from build output or Xcode.
+
+**Can be deferred to Sprint 6 if scope is tight.**
+
+---
+
+## Sequencing
+
+| Order | Part | Blocking? |
+|-------|------|-----------|
+| 1 | A — Release v1.0.3 + v1.0.4 | No |
+| 2 | B — Untracked voices decision | Needs user input |
+| 3 | C — requirements split | No |
+| 4 | D — launchd configure | Depends on A completing first |
+| 5 | E — App smoke test | Human needed, can defer |
+
+Start with A (no blockers), then C (no blockers), then D, then resolve B after user confirms the muse/vixen decision.
+
+---
+
+## Out of scope for Sprint 5
+
+- afterwords-cloud SaaS work (Sprint 6)
+- New voice reclones
+- Gemini CLI hook auto-configuration improvements

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,8 @@ httpx>=0.28.1,<1.0
 
 # mlx-audio is the runtime dep used by the qwen3 backend. Pinned here too so dev
 # environments installing only requirements-dev.txt can't float to 0.4.1+ (which
-# regressed Qwen3-1.7B ICL — generates EOS on first token).
+# regressed Qwen3-1.7B ICL — generates EOS on first token). Full pin rationale
+# (incl. the Metal thread-safety constraint) lives above the pin in requirements.txt.
 mlx-audio>=0.4,<0.4.1; sys_platform == "darwin"
 
 # Required to import conftest.py, backends/, and server.py in CI (no MLX/torch).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-# 0.4.1+ broke Qwen3-1.7B ICL (generates EOS on first token); pin below regression.
+# 0.4.1+ broke Qwen3-1.7B ICL cloning (generates EOS on first token). Separately,
+# MLX Metal is not thread-safe: all Metal ops run on the dedicated single-worker ML
+# executor (see CLAUDE.md "Architecture" and "Key Constraints"). Only lift this pin
+# after re-verifying both ICL cloning and executor thread-safety on the live server.
 mlx-audio>=0.4,<0.4.1
 soundfile>=0.13,<1.0
 fastapi>=0.135,<1.0

--- a/scripts/afterwords-post-llm.sh
+++ b/scripts/afterwords-post-llm.sh
@@ -126,6 +126,51 @@ fi
 
 # ── Messaging platform path: synthesize full audio, send as attachment ──
 if $MSG_PLATFORM; then
+    # ── Dedup: skip if we already sent audio for this exact text recently ──
+    # Compaction/retry loops can re-fire this hook with the same response text
+    # hundreds of times. Hash the text to detect duplicates and throttle.
+    # /tmp is shared: refuse a symlinked or foreign-owned dedup dir (same
+    # hardening as the queue dirs) — but proceed WITHOUT dedup rather than
+    # dropping the send.
+    DEDUP_DIR="/tmp/afterwords-dedup"
+    DEDUP_OK=true
+    if [ -L "$DEDUP_DIR" ]; then
+        DEDUP_OK=false
+    else
+        mkdir -p "$DEDUP_DIR" 2>/dev/null || true
+        chmod 700 "$DEDUP_DIR" 2>/dev/null || true
+        # stat -f%u is BSD (macOS); stat -c%u is GNU (Linux)
+        DEDUP_UID=$(stat -f%u "$DEDUP_DIR" 2>/dev/null || stat -c%u "$DEDUP_DIR" 2>/dev/null || echo "")
+        if [ ! -d "$DEDUP_DIR" ] || [ "$DEDUP_UID" != "$(id -u)" ]; then
+            DEDUP_OK=false
+        fi
+    fi
+    DEDUP_FILE=""
+    if $DEDUP_OK; then
+        # Expire stale markers so the dir does not accumulate forever
+        find "$DEDUP_DIR" -type f -mmin +60 -delete 2>/dev/null || true
+        TEXT_HASH=$(printf '%s' "$CLEAN" | python3 -c "
+import sys, hashlib
+print(hashlib.sha256(sys.stdin.read().encode()).hexdigest()[:16])
+" 2>/dev/null || echo "$(date +%s)$$")
+        DEDUP_FILE="${DEDUP_DIR}/${PLATFORM}-${TEXT_HASH}"
+        NOW_S=$(date +%s)
+        # Atomic claim via noclobber: concurrent re-fires with the same text
+        # race on this create, so create-or-fail picks a single winner instead
+        # of a check-then-write gap letting several through.
+        if ! (set -o noclobber; printf '%s\n' "$NOW_S" > "$DEDUP_FILE") 2>/dev/null; then
+            # Marker already exists: skip if we sent this text in the last 60s
+            # stat -f%m is BSD (macOS); stat -c%Y is GNU (Linux)
+            FILE_S=$(stat -f%m "$DEDUP_FILE" 2>/dev/null || stat -c%Y "$DEDUP_FILE" 2>/dev/null || echo 0)
+            AGE_S=$(( NOW_S - FILE_S ))
+            if [ "$AGE_S" -lt 60 ]; then
+                exit 0
+            fi
+            # Stale marker: refresh it and proceed
+            printf '%s\n' "$NOW_S" > "$DEDUP_FILE" 2>/dev/null || true
+        fi
+    fi
+
     # Concatenate all chunks into one text for single synthesize call
     SINGLE_WAV=$(mktemp /tmp/afterwords-msg-XXXXXX.wav)
     ENC=$(python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$CLEAN" 2>/dev/null || true)
@@ -195,18 +240,23 @@ os.replace(tmp, p)
             telegram)
                 OGG_CACHE="$AUDIO_CACHE_DIR/${SLUG}-${STAMP}.ogg"
                 cp "$OGG_FILE" "$OGG_CACHE" 2>/dev/null || true
-                hermes send -t "$SEND_TARGET" "MEDIA:$OGG_CACHE" 2>/dev/null || true
+                hermes send -t "$SEND_TARGET" "MEDIA:$OGG_CACHE" 2>/dev/null \
+                    || rm -f ${DEDUP_FILE:+"$DEDUP_FILE"}  # failed send: allow retry
                 ;;
             discord)
                 MP3_CACHE="$AUDIO_CACHE_DIR/${SLUG}-${STAMP}.mp3"
                 cp "$ARCHIVE_MP3" "$MP3_CACHE" 2>/dev/null || true
-                hermes send -t "$SEND_TARGET" "MEDIA:$MP3_CACHE" 2>/dev/null || true
+                hermes send -t "$SEND_TARGET" "MEDIA:$MP3_CACHE" 2>/dev/null \
+                    || rm -f ${DEDUP_FILE:+"$DEDUP_FILE"}  # failed send: allow retry
                 ;;
         esac
 
         rm -f "$SINGLE_WAV" "$OGG_FILE"
     else
         rm -f "$SINGLE_WAV"
+        # Failed synthesis: release the dedup marker so a legitimate retry
+        # of the same text within the window is not swallowed.
+        rm -f ${DEDUP_FILE:+"$DEDUP_FILE"}
     fi
     exit 0
 fi

--- a/tests/test_hermes_dedup.py
+++ b/tests/test_hermes_dedup.py
@@ -1,0 +1,193 @@
+"""Behavioral tests for the messaging-path dedup block in afterwords-post-llm.sh.
+
+Runs the real hook script via subprocess with stubbed external binaries
+(curl, lame, hermes, afplay, ffmpeg) on a prepended PATH. python3 stays real —
+the script shells out to it for JSON parsing, hashing, and markdown stripping.
+Each test uses uuid4 response text so the hardcoded /tmp/afterwords-dedup dir
+never collides across runs. CI-safe: no BSD-only tools in the tests themselves.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "afterwords-post-llm.sh"
+DEDUP_DIR = Path("/tmp/afterwords-dedup")  # hardcoded in the script
+
+# Stubs log every invocation as "<name> <argv>" to $STUB_LOG so tests can
+# assert which external calls actually happened.
+CURL_STUB = """#!/usr/bin/env bash
+printf 'curl %s\\n' "$*" >> "$STUB_LOG"
+# Two call shapes in the script:
+#   health: curl -s --max-time 2 URL            -> just exit 0
+#   synth:  curl -s -w %{http_code} -o FILE URL -> write FILE, print code
+# CURL_SYNTH_CODE (default 200) simulates synthesis failures.
+out=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "-o" ] && out="$a"
+  prev="$a"
+done
+if [ -n "$out" ]; then
+  code="${CURL_SYNTH_CODE:-200}"
+  [ "$code" = "200" ] && printf 'RIFF-fake-wav-payload' > "$out"
+  printf '%s' "$code"
+fi
+exit 0
+"""
+
+NOOP_STUB = """#!/usr/bin/env bash
+printf '{name} %s\\n' "$*" >> "$STUB_LOG"
+exit 0
+"""
+
+# hermes stub can simulate a failed send via HERMES_EXIT
+HERMES_STUB = """#!/usr/bin/env bash
+printf 'hermes %s\\n' "$*" >> "$STUB_LOG"
+exit "${HERMES_EXIT:-0}"
+"""
+
+
+@pytest.fixture
+def hook_env(tmp_path):
+    """Stub PATH + isolated HOME + empty cwd (no .afterwords lookups hit the repo)."""
+    # The script disables dedup when the shared dir is symlinked or foreign-
+    # owned; on such a machine these tests would fail confusingly — skip loud.
+    if DEDUP_DIR.is_symlink() or (
+        DEDUP_DIR.exists() and DEDUP_DIR.stat().st_uid != os.getuid()
+    ):
+        pytest.skip("/tmp/afterwords-dedup is symlinked or foreign-owned; script disables dedup")
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "curl").write_text(CURL_STUB)
+    (bindir / "hermes").write_text(HERMES_STUB)
+    for name in ("lame", "afplay", "ffmpeg"):
+        (bindir / name).write_text(NOOP_STUB.format(name=name))
+    for stub in bindir.iterdir():
+        stub.chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    log = tmp_path / "stub.log"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(home)
+    env["STUB_LOG"] = str(log)
+
+    # Teardown: remove only the markers this test created — the dedup dir is
+    # real shared state also used by the live Hermes hook on dev machines.
+    before = set(DEDUP_DIR.iterdir()) if DEDUP_DIR.is_dir() else set()
+    yield env, log, workdir
+    if DEDUP_DIR.is_dir():
+        for leftover in set(DEDUP_DIR.iterdir()) - before:
+            try:
+                leftover.unlink()
+            except OSError:
+                pass
+
+
+def run_hook(env, workdir, text, platform="discord"):
+    payload = json.dumps({"platform": platform, "response": text, "chat_id": "42"})
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=workdir,
+        timeout=30,
+    )
+
+
+def synth_calls(log):
+    """curl invocations that wrote a synth output file (-o); excludes the health check."""
+    if not log.exists():
+        return []
+    return [
+        line
+        for line in log.read_text().splitlines()
+        if line.startswith("curl") and " -o " in line
+    ]
+
+
+def unique_text():
+    return f"dedup regression check {uuid.uuid4().hex}"
+
+
+def test_first_run_synthesizes(hook_env):
+    env, log, workdir = hook_env
+    result = run_hook(env, workdir, unique_text())
+    assert result.returncode == 0, result.stderr
+    assert len(synth_calls(log)) == 1
+    # Delivery went out through the stub too
+    assert any(line.startswith("hermes send") for line in log.read_text().splitlines())
+
+
+def test_identical_text_is_deduped(hook_env):
+    env, log, workdir = hook_env
+    text = unique_text()
+    first = run_hook(env, workdir, text)
+    assert first.returncode == 0, first.stderr
+    assert len(synth_calls(log)) == 1
+    second = run_hook(env, workdir, text)
+    assert second.returncode == 0, second.stderr
+    # Marker is fresh (< 60s) -> second run exits before synthesizing
+    assert len(synth_calls(log)) == 1
+
+
+def test_different_text_still_synthesizes(hook_env):
+    env, log, workdir = hook_env
+    run_hook(env, workdir, unique_text())
+    run_hook(env, workdir, unique_text())
+    assert len(synth_calls(log)) == 2
+
+
+def test_failed_synthesis_releases_marker(hook_env):
+    env, log, workdir = hook_env
+    text = unique_text()
+    first = run_hook(dict(env, CURL_SYNTH_CODE="503"), workdir, text)
+    assert first.returncode == 0, first.stderr
+    assert len(synth_calls(log)) == 1
+    # Non-200 released the marker, so a retry of the SAME text is not swallowed
+    second = run_hook(env, workdir, text)
+    assert second.returncode == 0, second.stderr
+    assert len(synth_calls(log)) == 2
+
+
+def test_failed_send_releases_marker(hook_env):
+    env, log, workdir = hook_env
+    text = unique_text()
+    first = run_hook(dict(env, HERMES_EXIT="1"), workdir, text)
+    assert first.returncode == 0, first.stderr
+    assert len(synth_calls(log)) == 1
+    # hermes send failed -> marker released -> same-text retry synthesizes
+    second = run_hook(env, workdir, text)
+    assert second.returncode == 0, second.stderr
+    assert len(synth_calls(log)) == 2
+
+
+def test_stale_markers_are_expired(hook_env):
+    env, log, workdir = hook_env
+    DEDUP_DIR.mkdir(mode=0o700, exist_ok=True)
+    stale = DEDUP_DIR / f"discord-{uuid.uuid4().hex[:16]}"
+    stale.write_text("0")
+    old = time.time() - 4000  # > 60 minutes ago
+    os.utime(stale, (old, old))
+
+    result = run_hook(env, workdir, unique_text())
+    assert result.returncode == 0, result.stderr
+    # The expiry sweep (find -mmin +60 -delete) removed the stale marker
+    assert not stale.exists()
+    # ...and the run itself still synthesized normally
+    assert len(synth_calls(log)) == 1


### PR DESCRIPTION
## Summary
- **Doctrine (#101, #105):** adds `STRATEGY.md` (executor operating law: invariants, escalation triggers, verification order), read-first pointers at the end of `CLAUDE.md` and `AGENTS.md`, and documents the `.afterwords` tracked-defaults / never-commit-local-edits convention. Corrects the false tracked-lint claim from the 2026-06-21 hermes audit (#106 closed as invalid).
- **Hermes dedup (#102):** the messaging path (discord/telegram) now dedups identical response text for 60s via SHA-256 markers in `/tmp/afterwords-dedup` — atomic noclobber claim (closes a measured 69/100 duplicate-send race), marker release on failed synthesis/send so retries aren't swallowed, portable BSD/GNU `stat`, 60-min marker expiry, and the house shared-`/tmp` hardening (symlink refusal, chmod 700, owner check, degrade-to-no-dedup). Six behavioral tests drive the real script with stubbed externals.
- **Untracked docs (#103, partial):** commits the 2026-06-04 sprint5 plan; gitignores root-level `hermes_qa_*.md` reports. The 2026-06-10 security plan is deliberately withheld (names live-credential location + rotation state; `docs/` publishes to public Pages) — disposition on #103.
- **Deps (#104):** full mlx-audio `<0.4.1` pin rationale recorded next to both pins.

## QA
Ultracode workflow: 2 implementers → full-suite verify → 3-lens adversarial review with per-finding refutation (14 agents). 8 findings raised, 7 empirically confirmed, 6 fixed in this PR (retry-swallowing, TOCTOU race, stderr leak, test marker leakage, missing test precondition, dangling doc citation); the 7th (security-plan disclosure) is handled by withholding the file.

## Verification
- `pytest --tb=short -q` → **527 passed** (includes 6 new dedup tests)
- `python scripts/internal/check-og-metadata.py` → clean (193 profiles, 21 clips)
- `bash -n scripts/afterwords-post-llm.sh` → clean

Closes #101, #102, #104, #105.

https://claude.ai/code/session_01GEbBo2aQ1g8WVBtBZMpKne