### PR TITLE
chore(gitignore): keep 2026-06-10 security sprint plan local (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ voices/*.wav.bak
 /cache/
 /afterwords-redesign/
 /*.diff
+# 2026-06-10 security sprint plan stays local: it names live-credential storage
+# location + rotation status, and docs/ publishes to the public Pages site (#103)
+docs/superpowers/plans/2026-06-10-security-fix-sprint.md


### PR DESCRIPTION
Owner decision on #103 (option 1): gitignore the security sprint plan — it names live-credential storage location + rotation status, and docs/ publishes to the public Pages site. File stays local evidence. Closes #103.

https://claude.ai/code/session_01GEbBo2aQ1g8WVBtBZMpKne